### PR TITLE
KMCNG-80 fixes - support IE and FireFox

### DIFF
--- a/src/shared/kmc-content-ui/providers/content-metadata-profiles-store.service.ts
+++ b/src/shared/kmc-content-ui/providers/content-metadata-profiles-store.service.ts
@@ -100,21 +100,21 @@ export class ContentMetadataProfilesStore
         if (xsd) {
           const parser = new DOMParser();
           const schema = parser.parseFromString(xsd, "text/xml");      // create an xml documents from the schema
-          const elements = schema.getElementsByTagName("element");    // get all element nodes
+          const elements = schema.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "element");    // get all element nodes
 
           // for each xsd element with an ID attribute - search for a simpleType node of type listType - this means we have to add it to the filters if it is searchable
           for (let i = 0; i < elements.length; i++) {
             const currentNode = elements[i];
             if (currentNode.getAttribute("id") !== null) {            // only elements with ID attribue can be used for filters
-              const simpleTypes = currentNode.getElementsByTagName("simpleType");
+              const simpleTypes = currentNode.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "simpleType");
               if (simpleTypes.length > 0) {
                 // check if this element is searchable
-                if (currentNode.getElementsByTagName("searchable").length && currentNode.getElementsByTagName("searchable")[0].innerHTML === "true") {
+                if (currentNode.getElementsByTagName("searchable").length && currentNode.getElementsByTagName("searchable")[0].textContent === "true") {
                   // check if the simpleType type is "listType"
-                  if (simpleTypes[0].getElementsByTagName("restriction").length && simpleTypes[0].getElementsByTagName("restriction")[0].getAttribute("base") === "listType") {
+                  if (simpleTypes[0].getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "restriction").length && simpleTypes[0].getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "restriction")[0].getAttribute("base") === "listType") {
                     // get filter properties and add it to the metadata profile filters list
-                    const filterLabel = currentNode.getElementsByTagName("appinfo").length ? currentNode.getElementsByTagName("appinfo")[0].getElementsByTagName("label")[0].innerHTML : "";
-                    const valueNodes = simpleTypes[0].getElementsByTagName("enumeration");
+                    const filterLabel = currentNode.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "appinfo").length ? currentNode.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema" ,"appinfo")[0].getElementsByTagName("label")[0].innerHTML : "";
+                    const valueNodes = simpleTypes[0].getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "enumeration");
                     const values = [];
                     for (let j = 0; j < valueNodes.length; j++) {
                       values.push(valueNodes[j].getAttribute("value"));


### PR DESCRIPTION
Use getElementsByTagNameNS for supporting name spaces
use textContent instead of innerHTML to support IE