### PR TITLE
enable angular production mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,24 @@
 - **General -> logout**: The logout process was implemented with basic support. It will be handled as part of future delivry. At the moment, logout from the application will clear cache and reload the application.
 
 - **DevOp**: Upgrade dev dependencies:
-  - Upgrade webpack to 2.x and all its' loaders accordingly
-  - Upgrade typescript to 2.2.x
-  - Remove typings usage
-  - Add @Types dependencies
+  - Upgrade webpack to 2.x and all its' loaders accordingly.
+  - Upgrade typescript to 2.2.x.
+  - Remove typings usage.
+  - Add @Types dependencies.
  
 - **DevOp**: Optimize build process and deployed package: 
-  - Reduce javascript bundle sized
-  - Minify javascript code
-  - Lazy loading support for views
-  - Angular2 component template & styles support
+  - Reduce javascript bundle sized.
+  - Minify javascript code.
+  - Lazy loading support for views.
+  - Angular2 component template & styles support.
   - Theme bundling and assets re-organization.
+  - Enable Angular runtime production mode.
+  - Enable [angular debug tools](https://github.com/angular/angular/blob/86405345b781a9dc2438c0fbe3e9409245647019/TOOLS_JS.md).  
+  
+ 
+- **DevOp**: Print application version in console during app load.
+
+
 
 ### Bug Fixes
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,12 +1,12 @@
 const helpers = require('./helpers');
 const webpackMerge = require('webpack-merge'); // used to merge webpack configs
 const commonConfig = require('./webpack.common.js'); // the settings that are common to prod and dev
+const packageJson = require('../package.json');
 
 /**
  * Webpack Plugins
  */
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
-const AssetsPlugin = require('assets-webpack-plugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
 
@@ -95,12 +95,16 @@ module.exports = function (options) {
        */
       // NOTE: when adding more properties, make sure you include them in custom-typings.d.ts
       new DefinePlugin({
+      	'__KMCng__' :
+	        {
+		        version : JSON.stringify(packageJson.version)
+	        },
         'ENV': JSON.stringify(METADATA.ENV),
         'HMR': METADATA.HMR,
         'process.env': {
           'ENV': JSON.stringify(METADATA.ENV),
           'NODE_ENV': JSON.stringify(METADATA.ENV),
-          'HMR': METADATA.HMR,
+          'HMR': METADATA.HMR
         }
       }),
 

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,6 +1,7 @@
 const helpers = require('./helpers');
 const webpackMerge = require('webpack-merge'); // used to merge webpack configs
 const commonConfig = require('./webpack.common.js'); // the settings that are common to prod and dev
+const packageJson = require('../package.json');
 
 /**
  * Webpack Plugins
@@ -99,12 +100,16 @@ module.exports = function (env) {
 			 */
 			// NOTE: when adding more properties make sure you include them in custom-typings.d.ts
 			new DefinePlugin({
+				'__KMCng__' :
+					{
+						version : JSON.stringify(packageJson.version)
+					},
 				'ENV': JSON.stringify(METADATA.ENV),
 				'HMR': METADATA.HMR,
 				'process.env': {
 					'ENV': JSON.stringify(METADATA.ENV),
 					'NODE_ENV': JSON.stringify(METADATA.ENV),
-					'HMR': METADATA.HMR,
+					'HMR': METADATA.HMR
 				}
 			}),
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "JSON.sh": "^0.3.2",
     "add-asset-html-webpack-plugin": "^1.0.2",
     "angular2-template-loader": "^0.6.0",
-    "assets-webpack-plugin": "^3.4.0",
     "awesome-typescript-loader": "~3.0.0-beta.18",
     "codelyzer": "~2.0.0-beta.4",
     "copy-webpack-plugin": "^4.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, enableProdMode } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpModule } from '@angular/http';
@@ -31,12 +31,6 @@ import { KalturaHttpConfigurationAdapter } from "./services/kaltura-http-configu
 import { ButtonModule, InputTextModule, TieredMenuModule } from 'primeng/primeng';
 
 import { KMCContentUIModule } from 'kmc-content-ui/kmc-content-ui.module';
-
-
-// depending on the env mode, enable prod mode or add debugging modules
-if (process.env.ENV === 'build') {
-  enableProdMode();
-}
 
 @NgModule({
   imports: <any>[

--- a/src/app/environment.ts
+++ b/src/app/environment.ts
@@ -1,0 +1,64 @@
+// Angular 2
+import {
+  enableDebugTools,
+  disableDebugTools
+} from '@angular/platform-browser';
+import {
+  ApplicationRef,
+  enableProdMode
+} from '@angular/core';
+// Environment Providers
+let PROVIDERS: any[] = [
+  // common env directives
+];
+
+// Angular debug tools in the dev console
+// https://github.com/angular/angular/blob/86405345b781a9dc2438c0fbe3e9409245647019/TOOLS_JS.md
+let _decorateModuleRef = <T>(value: T): T => { return value; };
+
+if ('production' === ENV) {
+  console.log(`Running KMCng version '${__KMCng__.version}' (Production mode)`);
+  enableProdMode();
+
+  // Production
+  _decorateModuleRef = (modRef: any) => {
+    disableDebugTools();
+
+    return modRef;
+  };
+
+  PROVIDERS = [
+    ...PROVIDERS,
+    // custom providers in production
+  ];
+
+}
+
+if ('production' !== ENV) {
+
+  console.log(`Running KMCng version '${__KMCng__.version}' (Development mode)`);
+
+  _decorateModuleRef = (modRef: any) => {
+    const appRef = modRef.injector.get(ApplicationRef);
+    const cmpRef = appRef.components[0];
+
+    let _ng = (<any> window).ng;
+    enableDebugTools(cmpRef);
+    (<any> window).ng.probe = _ng.probe;
+    (<any> window).ng.coreTokens = _ng.coreTokens;
+    return modRef;
+  };
+
+  // Development
+  PROVIDERS = [
+    ...PROVIDERS,
+    // custom providers in development
+  ];
+
+}
+
+export const decorateModuleRef = _decorateModuleRef;
+
+export const ENV_PROVIDERS = [
+  ...PROVIDERS
+];

--- a/src/custom-typings.d.ts
+++ b/src/custom-typings.d.ts
@@ -1,0 +1,134 @@
+/*
+ * Custom Type Definitions
+ * When including 3rd party modules you also need to include the type definition for the module
+ * if they don't provide one within the module. You can try to install it with @types
+
+npm install @types/node
+npm install @types/lodash
+
+ * If you can't find the type definition in the registry we can make an ambient/global definition in
+ * this file for now. For example
+
+declare module 'my-module' {
+ export function doesSomething(value: string): string;
+}
+
+ * If you are using a CommonJS module that is using module.exports then you will have to write your
+ * types using export = yourObjectOrFunction with a namespace above it
+ * notice how we have to create a namespace that is equal to the function we're
+ * assigning the export to
+
+declare module 'jwt-decode' {
+  function jwtDecode(token: string): any;
+  namespace jwtDecode {}
+  export = jwtDecode;
+}
+
+ *
+ * If you're prototying and you will fix the types later you can also declare it as type any
+ *
+
+declare var assert: any;
+declare var _: any;
+declare var $: any;
+
+ *
+ * If you're importing a module that uses Node.js modules which are CommonJS you need to import as
+ * in the files such as main.browser.ts or any file within app/
+ *
+
+import * as _ from 'lodash'
+
+ * You can include your type definitions in this file until you create one for the @types
+ *
+ */
+
+// support NodeJS modules without type definitions
+//declare module '*';
+
+/*
+// for legacy tslint etc to understand rename 'modern-lru' with your package
+// then comment out `declare module '*';`. For each new module copy/paste
+// this method of creating an `any` module type definition
+declare module 'modern-lru' {
+  let x: any;
+  export = x;
+}
+*/
+
+// Extra variables that live on Global that will be replaced by webpack DefinePlugin
+declare var ENV: string;
+declare var KMCngVersion : string;
+declare var HMR: boolean;
+declare var System: SystemJS;
+declare var __KMCng__ : {
+  version : string
+};
+
+interface SystemJS {
+  import: (path?: string) => Promise<any>;
+}
+
+interface GlobalEnvironment {
+  ENV: string;
+  HMR: boolean;
+  SystemJS: SystemJS;
+  System: SystemJS;
+}
+
+interface Es6PromiseLoader {
+  (id: string): (exportName?: string) => Promise<any>;
+}
+
+type FactoryEs6PromiseLoader = () => Es6PromiseLoader;
+type FactoryPromise = () => Promise<any>;
+
+type AsyncRoutes = {
+  [component: string]: Es6PromiseLoader |
+                               Function |
+                FactoryEs6PromiseLoader |
+                         FactoryPromise
+};
+
+type IdleCallbacks = Es6PromiseLoader |
+                             Function |
+              FactoryEs6PromiseLoader |
+                       FactoryPromise ;
+
+interface WebpackModule {
+  hot: {
+    data?: any,
+    idle: any,
+    accept(dependencies?: string | string[], callback?: (updatedDependencies?: any) => void): void;
+    decline(deps?: any | string | string[]): void;
+    dispose(callback?: (data?: any) => void): void;
+    addDisposeHandler(callback?: (data?: any) => void): void;
+    removeDisposeHandler(callback?: (data?: any) => void): void;
+    check(autoApply?: any, callback?: (err?: Error, outdatedModules?: any[]) => void): void;
+    apply(options?: any, callback?: (err?: Error, outdatedModules?: any[]) => void): void;
+    status(callback?: (status?: string) => void): void | string;
+    removeStatusHandler(callback?: (status?: string) => void): void;
+  };
+}
+
+interface WebpackRequire {
+    (id: string): any;
+    (paths: string[], callback: (...modules: any[]) => void): void;
+    ensure(ids: string[], callback: (req: WebpackRequire) => void, chunkName?: string): void;
+    context(directory: string, useSubDirectories?: boolean, regExp?: RegExp): WebpackContext;
+}
+
+interface WebpackContext extends WebpackRequire {
+    keys(): string[];
+}
+
+interface ErrorStackTraceLimit {
+  stackTraceLimit: number;
+}
+
+// Extend typings
+interface NodeRequire extends WebpackRequire {}
+interface ErrorConstructor extends ErrorStackTraceLimit {}
+interface NodeRequireFunction extends Es6PromiseLoader  {}
+interface NodeModule extends WebpackModule {}
+interface Global extends GlobalEnvironment  {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,20 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { decorateModuleRef } from './app/environment';
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic().bootstrapModule(AppModule);
+if (window) {
+    window['__KMCng__'] = {
+        version: __KMCng__.version
+    };
+}
+
+(function()
+{
+    platformBrowserDynamic()
+        .bootstrapModule(AppModule)
+        .then(decorateModuleRef)
+        .catch(function(err)
+        {
+            console.error(err);
+        });
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl" : ".",
     "target": "es5",
-    "module": "commonjs",
+    "module": "es2015",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Angular2 was using development mode also when deployed using `npm run build:prod`


**What is the new behavior?**
- When building to production, set angular2 to production mode
- When loading application, write to console the version of the application and whether is is in dev/prod mode
- 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**


**How should this be manually tested?**
build the application (only KMCng is needed, the infra was left as-is) and test it in relevant browsers.

**Any background context you want to provide?**