### PR TITLE
KMCNG-1172 Unable to choose 'Transcoding Profile' while preparing entry

### DIFF
--- a/src/applications/kmc-upload-app/prepare-entry/prepare-entry.component.html
+++ b/src/applications/kmc-upload-app/prepare-entry/prepare-entry.component.html
@@ -1,4 +1,4 @@
-<kPopupWidget #transcodingProfileSelectMenu [popupWidth]="586" [popupHeight]="289" [closeBtn]="true" [modal]="true">
+<kPopupWidget #transcodingProfileSelectMenu [popupWidth]="586" [popupHeight]="289" [closeBtn]="true" [modal]="true" [preventPageScroll]="true">
   <ng-template>
     <kTranscodingProfileSelect (onTranscodingProfileSelected)="_loadEntry($event)" [parentPopupWidget]="transcodingProfileSelectMenu" [mediaType]="_selectedMediaType"></kTranscodingProfileSelect>
   </ng-template>

--- a/src/applications/kmc-upload-app/prepare-entry/prepare-entry.component.ts
+++ b/src/applications/kmc-upload-app/prepare-entry/prepare-entry.component.ts
@@ -28,7 +28,7 @@ export class PrepareEntryComponent implements OnInit {
     this._selectedMediaType = kalturaMediaType;
     // TODO [kmcng] If user permissions allows setting transcoding profile - show transcoding profile selector
     // 'transcodingProfileSettingPermission' should contain whether the user has the permission to set the transcoding profile
-    const transcodingProfileSettingPermission = false;
+    const transcodingProfileSettingPermission = true;
     if (transcodingProfileSettingPermission) {
       this.transcodingProfileSelectMenu.open();
     } else {


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

Steps to reproduce:
a. Press on 'Create' button
b. Choose Video/Audio from 'Prepare Entry' section
Expected results:
'Transcoding Profile' screen is displayed
Actual results:
No 'Transcoding Profile' screen is displayed
Note:
in old KMC the drop-down is displayed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/325)
<!-- Reviewable:end -->
