### PR TITLE
handle creation errors correctly

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -513,6 +513,8 @@
         "name": "Name",
         "categoryMovedSuccessfully": "Category moved successfully",
         "errors": {
+          "cannotLinkEntries": "Category was created, but failed to link some of the entries, please review the created category",
+          "createFailed": "An error occurred while trying to add new category",
           "requiredName": "You must enter name",
           "unableToLoadParentCategoryId" : "Unable to load Parent Category ID"
         }


### PR DESCRIPTION
- kmcng-1279
- kmcng-1266
- kmcng-1267
- remove navigate confirmation upon successful creation of category.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/386)
<!-- Reviewable:end -->
