### PR TITLE
Remove setAppStatus, replace with alert

### DIFF
--- a/src/applications/content-categories-app/categories/bulk-actions/categories-bulk-actions.component.ts
+++ b/src/applications/content-categories-app/categories/bulk-actions/categories-bulk-actions.component.ts
@@ -177,9 +177,8 @@ export class CategoriesBulkActionsComponent implements OnInit, OnDestroy {
           }, 0);
         }
       }, error => {
-        this._browserService.setAppStatus({
-          errorMessage: this._appLocalization
-            .get('applications.content.categoryDetails.subcategories.errors.categoriesCouldNotBeDeleted')
+        this._browserService.alert({
+          message: this._appLocalization.get('applications.content.categoryDetails.subcategories.errors.categoriesCouldNotBeDeleted')
         });
       });
   }
@@ -191,8 +190,9 @@ export class CategoriesBulkActionsComponent implements OnInit, OnDestroy {
       });
 
       if (!movingOnlySiblings) {
-        this._browserService.setAppStatus(
-          {errorMessage: this._appLocalization.get('applications.content.moveCategory.errors.onlySiblingsMoveAllowed')});
+        this._browserService.alert({
+          message: this._appLocalization.get('applications.content.moveCategory.errors.onlySiblingsMoveAllowed')
+        });
       } else {
         this.openBulkActionWindow('moveCategories', 586, 580);
       }
@@ -226,7 +226,9 @@ export class CategoriesBulkActionsComponent implements OnInit, OnDestroy {
           this.onBulkChange.emit({ reload: reloadCategories });
         },
         error => {
-          this._browserService.setAppStatus({ errorMessage: this._appLocalization.get('applications.content.bulkActions.errorCategories') });
+          this._browserService.alert({
+            message: this._appLocalization.get('applications.content.bulkActions.errorCategories')
+          });
           this.onBulkChange.emit({ reload: reloadCategories });
         }
       );

--- a/src/applications/content-entries-app/entries/bulk-actions/bulk-actions.component.ts
+++ b/src/applications/content-entries-app/entries/bulk-actions/bulk-actions.component.ts
@@ -253,7 +253,7 @@ export class BulkActionsComponent implements OnInit, OnDestroy {
           const message = error.type === 'bulkDelete'
             ? error.message
             : this._appLocalization.get('applications.content.bulkActions.error');
-          this._browserService.setAppStatus({errorMessage: message });
+          this._browserService.alert({ message });
         }
       );
     };

--- a/src/applications/kmc-upload-app/prepare-entry/prepare-entry.component.ts
+++ b/src/applications/kmc-upload-app/prepare-entry/prepare-entry.component.ts
@@ -47,8 +47,8 @@ export class PrepareEntryComponent implements OnInit {
           this.transcodingProfileSelectMenu.close();
         },
         error => {
-          this._browserService.setAppStatus({
-            errorMessage: error.message
+          this._browserService.alert({
+            message: error.message
           });
         });
   }

--- a/src/kmc-app/app.component.html
+++ b/src/kmc-app/app.component.html
@@ -1,4 +1,4 @@
-<k-area-blocker [showLoader]="_isBusy" [message]="_blockerMessage" [bodyScroll]="true" [classes]="'kAreaBlockerCoverAll'">
+<k-area-blocker [showLoader]="_isBusy" [bodyScroll]="true" [classes]="'kAreaBlockerCoverAll'">
     <router-outlet></router-outlet>
 </k-area-blocker>
 <!--router-outlet></router-outlet-->

--- a/src/kmc-app/app.component.ts
+++ b/src/kmc-app/app.component.ts
@@ -19,7 +19,6 @@ import { UploadPageExitVerificationService } from 'app-shared/kmc-shell/page-exi
 export class AppComponent implements OnInit {
 
   public _isBusy: boolean = false;
-  public _blockerMessage: AreaBlockerMessage = null;
   public _growlMessages: GrowlMessage[] = [];
 
   constructor(private _confirmationService: ConfirmationService,
@@ -44,24 +43,6 @@ export class AppComponent implements OnInit {
           window.scrollTo(0, 0);
         }
       });
-
-    // handle app status: busy and error messages. Allow closing error window using the 'OK' button
-    this._browserService.appStatus$.subscribe(
-      (status: AppStatus) => {
-        if ( status.errorMessage !== null ){
-          this._blockerMessage = new AreaBlockerMessage({
-            message: status.errorMessage,
-            buttons: [{
-              label: this._appLocalization.get('app.common.ok'),
-              action: () => {
-                this._isBusy = false;
-                this._blockerMessage = null;
-              }
-            }]
-          });
-        }
-      }
-    );
 
     // handle app status: busy and error messages. Allow closing error window using the 'OK' button
     this._oprationsTagManager.tagStatus$.subscribe(

--- a/src/shared/kmc-shell/providers/browser.service.ts
+++ b/src/shared/kmc-shell/providers/browser.service.ts
@@ -39,10 +39,8 @@ export enum UnpermittedActionReasons {
 @Injectable()
 export class BrowserService implements IAppStorage {
 
-  private _appStatus = new BehaviorSubject<{errorMessage : string}>({ errorMessage : null});
   private _growlMessage = new Subject<GrowlMessage>();
   private _sessionStartedAt: Date = new Date();
-  public appStatus$ = this._appStatus.asObservable();
   public growlMessage$ = this._growlMessage.asObservable();
 
 	private _onConfirmationFn : OnShowConfirmationFn = (confirmation : Confirmation) => {
@@ -101,10 +99,6 @@ export class BrowserService implements IAppStorage {
 			this._onConfirmationFn = fn;
 		}
 	}
-
-	public setAppStatus(status: AppStatus): void{
-    this._appStatus.next(status);
-  }
 
 	public confirm(confirmation : Confirmation) {
 		confirmation.key = "confirm";


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [] Bugfix
- [] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Some parts of the code were using `setAppStatus` function of the `BrowserService`


**What is the new behavior?**
Remove `setAppStatus` function, replace its calls with `alert` function


**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/404)
<!-- Reviewable:end -->
