### PR TITLE
Fix entries-list pagination cache token

### DIFF
--- a/src/applications/content-entries-app/content-entries.component.ts
+++ b/src/applications/content-entries-app/content-entries.component.ts
@@ -1,21 +1,19 @@
 import { Component } from '@angular/core';
-import { EntriesStore } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
+import { EntriesStore, EntriesStorePaginationCacheToken } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
 import { KalturaLogger, KalturaLoggerName } from '@kaltura-ng/kaltura-logger';
 
 @Component({
-    selector: 'kEntries',
-    templateUrl: './content-entries.component.html',
-    styleUrls: ['./content-entries.component.scss'],
-    providers : [
-        EntriesStore,
-        KalturaLogger,
-        {
-            provide: KalturaLoggerName, useValue: 'entries-store.service'
-        }
-    ]
+  selector: 'kEntries',
+  templateUrl: './content-entries.component.html',
+  styleUrls: ['./content-entries.component.scss'],
+  providers: [
+    EntriesStore,
+    KalturaLogger,
+    { provide: KalturaLoggerName, useValue: 'entries-store.service' },
+    { provide: EntriesStorePaginationCacheToken, useValue: 'entries-list' }
+  ]
 })
-export class ContentEntriesComponent  {
-
+export class ContentEntriesComponent {
 
 
 }

--- a/src/applications/content-entries-app/entries/entries-list-holder.component.ts
+++ b/src/applications/content-entries-app/entries/entries-list-holder.component.ts
@@ -56,7 +56,6 @@ export class EntriesListHolderComponent {
               private _appLocalization: AppLocalization,
               public _entriesStore: EntriesStore,
               private _contentEntriesAppService: ContentEntriesAppService) {
-    this._entriesStore.paginationCacheToken = 'entries-list';
   }
 
   public _onActionSelected({ action, entry }) {

--- a/src/applications/content-moderation-app/content-moderation.component.ts
+++ b/src/applications/content-moderation-app/content-moderation.component.ts
@@ -1,11 +1,14 @@
 import { Component } from '@angular/core';
-import { EntriesStore } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
+import { EntriesStore, EntriesStorePaginationCacheToken } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
 
 @Component({
   selector: 'kModeration',
   templateUrl: './content-moderation.component.html',
   styleUrls: ['./content-moderation.component.scss'],
-  providers: [EntriesStore]
+  providers: [
+    EntriesStore,
+    { provide: EntriesStorePaginationCacheToken, useValue: 'moderation-entries-list' }
+  ]
 })
 export class ContentModerationComponent {
 }

--- a/src/applications/content-moderation-app/entries/entries-list-holder.component.ts
+++ b/src/applications/content-moderation-app/entries/entries-list-holder.component.ts
@@ -72,7 +72,6 @@ export class EntriesListHolderComponent implements OnDestroy {
               private _appLocalization: AppLocalization,
               private _entriesStore: EntriesStore,
               private _bulkService: BulkService) {
-    this._entriesStore.paginationCacheToken = 'moderation-entries-list';
   }
 
   ngOnDestroy() {

--- a/src/applications/content-playlists-app/playlist/playlist-content/rule-based/playlist-rule/playlist-entries-data-provider.service.ts
+++ b/src/applications/content-playlists-app/playlist/playlist-content/rule-based/playlist-rule/playlist-entries-data-provider.service.ts
@@ -253,14 +253,14 @@ export class PlaylistEntriesDataProvider implements EntriesDataProvider, OnDestr
       );
   }
 
-  public getDefaultFilterValues(savedAutoSelectChildren: CategoriesModes): EntriesFilters {
+  public getDefaultFilterValues(savedAutoSelectChildren: CategoriesModes, pageSize: number): EntriesFilters {
     const categoriesMode = typeof savedAutoSelectChildren === 'number'
       ? savedAutoSelectChildren
       : CategoriesModes.SelfAndChildren;
 
     return {
       freetext: '',
-      pageSize: 50,
+      pageSize: pageSize,
       pageIndex: 0,
       sortBy: 'plays',
       sortDirection: SortDirection.Desc,

--- a/src/applications/content-playlists-app/playlist/playlist-content/rule-based/playlist-rule/playlist-rule.component.ts
+++ b/src/applications/content-playlists-app/playlist/playlist-content/rule-based/playlist-rule/playlist-rule.component.ts
@@ -1,6 +1,9 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { EntriesListComponent } from 'app-shared/content-shared/entries/entries-list/entries-list.component';
-import { EntriesFilters, EntriesStore, SortDirection } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
+import {
+  EntriesFilters, EntriesStore, EntriesStorePaginationCacheToken,
+  SortDirection
+} from 'app-shared/content-shared/entries/entries-store/entries-store.service';
 import { EntriesTableColumns } from 'app-shared/content-shared/entries/entries-table/entries-table.component';
 import { KalturaPlayableEntryOrderBy } from 'kaltura-ngx-client/api/types/KalturaPlayableEntryOrderBy';
 import { AppLocalization } from '@kaltura-ng/kaltura-common/localization/app-localization.service';
@@ -16,7 +19,10 @@ import { AreaBlockerMessage } from '@kaltura-ng/kaltura-ui/area-blocker/area-blo
   selector: 'kPlaylistRule',
   templateUrl: './playlist-rule.component.html',
   styleUrls: ['./playlist-rule.component.scss'],
-  providers: [PlaylistRuleParserService]
+  providers: [
+    PlaylistRuleParserService,
+    { provide: EntriesStorePaginationCacheToken, useValue: 'entries-list' }
+  ]
 })
 export class PlaylistRuleComponent implements OnInit {
   @Input() rule: PlaylistRule;
@@ -82,7 +88,6 @@ export class PlaylistRuleComponent implements OnInit {
               private _browserService: BrowserService,
               private _appLocalization: AppLocalization,
               private _playlistRuleParser: PlaylistRuleParserService) {
-    this._entriesStore.paginationCacheToken = 'entries-list';
   }
 
   ngOnInit() {

--- a/src/shared/content-shared/entries/entries-selector/entries-selector.component.ts
+++ b/src/shared/content-shared/entries/entries-selector/entries-selector.component.ts
@@ -1,6 +1,9 @@
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { EntriesListComponent } from 'app-shared/content-shared/entries/entries-list/entries-list.component';
-import { EntriesFilters, EntriesStore } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
+import {
+  EntriesFilters, EntriesStore,
+  EntriesStorePaginationCacheToken
+} from 'app-shared/content-shared/entries/entries-store/entries-store.service';
 import { AreaBlockerMessage } from '@kaltura-ng/kaltura-ui';
 import { EntriesTableColumns } from 'app-shared/content-shared/entries/entries-table/entries-table.component';
 import { KalturaMediaEntry } from 'kaltura-ngx-client/api/types/KalturaMediaEntry';
@@ -11,7 +14,10 @@ import { KalturaTypesFactory } from 'kaltura-ngx-client';
   selector: 'kEntriesSelector',
   templateUrl: './entries-selector.component.html',
   styleUrls: ['./entries-selector.component.scss'],
-  providers: [EntriesStore]
+  providers: [
+    EntriesStore,
+    { provide: EntriesStorePaginationCacheToken, useValue: 'entries-selector' }
+  ]
 })
 export class EntriesSelectorComponent {
   @Input() selectedEntries: KalturaMediaEntry[] = [];
@@ -31,7 +37,6 @@ export class EntriesSelectorComponent {
   };
 
   constructor(public _entriesStore: EntriesStore) {
-    this._entriesStore.paginationCacheToken = 'entries-selector';
   }
 
   public _onActionSelected({ action, entry }: { action: string, entry: KalturaMediaEntry }): void {

--- a/src/shared/content-shared/entries/entries-store/entries-store-data-provider.service.ts
+++ b/src/shared/content-shared/entries/entries-store/entries-store-data-provider.service.ts
@@ -298,14 +298,14 @@ export class EntriesStoreDataProvider implements EntriesDataProvider, OnDestroy 
       );
   }
 
-  public getDefaultFilterValues(savedAutoSelectChildren: CategoriesModes): EntriesFilters {
+  public getDefaultFilterValues(savedAutoSelectChildren: CategoriesModes, pageSize: number): EntriesFilters {
     const categoriesMode = typeof savedAutoSelectChildren === 'number'
       ? savedAutoSelectChildren
       : CategoriesModes.SelfAndChildren;
 
     return {
       freetext: '',
-      pageSize: 50,
+      pageSize: pageSize,
       pageIndex: 0,
       sortBy: 'createdAt',
       sortDirection: SortDirection.Desc,


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Show rows param always was resetting to default value when user leaves entries-list page


**What is the new behavior?**
Use injection token to define pagination cache key to prevent current behavior


**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/413)
<!-- Reviewable:end -->
