### PR TITLE
Custom Data > Fix applyTo always set to entries

### DIFF
--- a/src/applications/settings-custom-data-app/schemas/custom-schema/custom-schema-form/custom-schema-form.component.ts
+++ b/src/applications/settings-custom-data-app/schemas/custom-schema/custom-schema-form/custom-schema-form.component.ts
@@ -89,7 +89,7 @@ export class CustomSchemaFormComponent {
 
       if (change.applyTo) {
         const applyTo = change.applyTo;
-        if (!this._schema.applyTo === applyTo) {
+        if (this._schema.applyTo !== applyTo) {
           this._schema.applyTo = applyTo;
           sendUpdate = true;
         }


### PR DESCRIPTION
### PR information

**What is the current behavior?**
New custom data schemas always are applied to entries


**What is the new behavior?**
Fix apply to switching


**Does this PR introduce a breaking change?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/486)
<!-- Reviewable:end -->
