### PR TITLE
Allow user login by ks in query params

### DIFF
--- a/src/kmc-app/app.module.ts
+++ b/src/kmc-app/app.module.ts
@@ -84,6 +84,7 @@ import { getKalturaServerUri } from 'config/server';
 import { KMCAuthenticationEvents } from './kmc-authentication-events';
 import { StorageProfilesStore } from 'app-shared/kmc-shared/storage-profiles';
 import { TranscodingProfileCreationModule } from 'app-shared/kmc-shared/events/transcoding-profile-creation/transcoding-profile-creation.module';
+import { LoginActionsComponent } from './components/login/login-actions/login-actions.component';
 
 const partnerProviders: PartnerProfileStore[] = [AccessControlProfileStore, FlavoursStore, PlayersStore, StorageProfilesStore];
 
@@ -157,7 +158,8 @@ export function kalturaClientOptionsFactory(): KalturaClientOptions {
     InvalidLoginHashFormComponent,
     ChangeAccountComponent,
     ChangelogComponent,
-    ChangelogContentComponent
+    ChangelogContentComponent,
+      LoginActionsComponent
   ],
   bootstrap: <any>[
     AppComponent

--- a/src/kmc-app/app.routes.ts
+++ b/src/kmc-app/app.routes.ts
@@ -4,6 +4,7 @@ import {AppBootstrap, AuthCanActivate} from 'app-shared/kmc-shell';
 import {LoginComponent} from './components/login/login.component';
 import {DashboardComponent} from './components/dashboard/dashboard.component';
 import {ErrorComponent} from './components/error/error.component';
+import { LoginActionsComponent } from './components/login/login-actions/login-actions.component';
 
 const routes: Routes = <Routes>[
   {
@@ -12,7 +13,12 @@ const routes: Routes = <Routes>[
   {
     path: '', canActivate: [AppBootstrap],
     children: [
-      { path: 'login', component: LoginComponent },
+      {
+          path: 'login', children: [
+              { path: '', component: LoginComponent },
+              { path: 'actions/:action', component: LoginActionsComponent },
+          ]
+      },
       {
           path: '', redirectTo: '/content/entries/list', pathMatch: 'full'
       },

--- a/src/kmc-app/components/login/login-actions/login-actions.component.ts
+++ b/src/kmc-app/components/login/login-actions/login-actions.component.ts
@@ -1,0 +1,68 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { KalturaLogger } from '@kaltura-ng/kaltura-logger/kaltura-logger.service';
+import { AppAuthentication } from 'app-shared/kmc-shell';
+import { AppNavigator } from 'app-shared/kmc-shell/auth/app-navigator.service';
+
+@Component({
+    selector: 'kKMCLoginActions',
+    template: '<k-area-blocker classes="kAreaBlockerCoverAll" [showLoader]="true"></k-area-blocker>',
+    providers: [KalturaLogger.createLogger('LoginActionsComponent')]
+})
+export class LoginActionsComponent implements OnInit, OnDestroy {
+    constructor(private _route: ActivatedRoute,
+                private _router: Router,
+                private _appAuth: AppAuthentication,
+                private _appNavigator: AppNavigator,
+                private _logger: KalturaLogger) {
+
+    }
+
+    ngOnInit() {
+        this._prepare();
+    }
+
+    ngOnDestroy() {
+
+    }
+
+    private _prepare(): void {
+        this._route.params
+            .cancelOnDestroy(this)
+            .subscribe(param => {
+                switch (param['action']) {
+                    case 'login-by-ks':
+                        this._logger.info(`handle 'login-by-ks' action`);
+                        this._handleLoginByKS(this._route.snapshot.queryParams['ks']);
+                        break;
+                    default:
+                        this._logger.info(`unknown action received, redirect to login page`, { action: param['action'] });
+                        this._router.navigate(['/login']);
+                        break;
+                }
+            });
+    }
+
+    private _handleLoginByKS(ks: string): void {
+        if (typeof ks !== 'string' || !ks.trim()) {
+            this._logger.info(`ks is not defined, redirect to login page`);
+            this._router.navigate(['/login']);
+            return;
+        }
+
+        this._logger.info(`try to login by ks provided from query params`, { ks });
+
+        this._appAuth.loginByKS(ks)
+            .cancelOnDestroy(this)
+            .subscribe(result => {
+                if (result) {
+                    this._logger.info(`login successful, navigate to the default page`);
+                    this._appNavigator.navigateToDefault();
+                } else {
+                    this._logger.info(`login failed, navigate to the login page`);
+                    this._router.navigate(['/login']);
+                }
+            });
+
+    }
+}

--- a/src/shared/kmc-shell/auth/app-authentication.service.ts
+++ b/src/shared/kmc-shell/auth/app-authentication.service.ts
@@ -247,20 +247,19 @@ export class AppAuthentication {
         this._logout();
     }
 
-    public loginAutomatically(): Observable<boolean> {
+    public loginByKS(loginToken: string): Observable<boolean> {
         return Observable.create((observer: any) => {
             if (!this.isLogged()) {
-                const loginToken = this.appStorage.getFromSessionStorage('auth.login.ks');  // get ks from session storage
                 if (loginToken) {
                     const requests = [
                         new UserGetAction({})
                             .setRequestOptions({
-                            ks: loginToken
-                        }),
+                                ks: loginToken
+                            }),
                         new PartnerGetInfoAction({})
                             .setRequestOptions({
-                            ks: loginToken
-                        })
+                                ks: loginToken
+                            })
                             .setDependency(['id', 0, 'partnerId']),
                         new UserRoleGetAction({ userRoleId: 0})
                             .setRequestOptions({
@@ -305,6 +304,11 @@ export class AppAuthentication {
                 }
             }
         });
+    }
+
+    public loginAutomatically(): Observable<boolean> {
+        const loginToken = this.appStorage.getFromSessionStorage('auth.login.ks');  // get ks from session storage
+        return this.loginByKS(loginToken);
     }
 
     public switchPartnerId(partnerId: number): Observable<void> {


### PR DESCRIPTION
### PR information

**What is the current behavior?**



**What is the new behavior?**
A user can login into the app using login actions and ks.
To log in with the ks type `[domain]/login/actions/login-by-ks?ks=[token]` into url field of the browser

**Does this PR introduce a breaking change?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/604)
<!-- Reviewable:end -->
