### PR TITLE
Fix entries table columns styles

### DIFF
--- a/src/shared/content-shared/entries/entries-table/entries-table.component.html
+++ b/src/shared/content-shared/entries/entries-table/entries-table.component.html
@@ -17,44 +17,44 @@
                 <th style="width:44px; padding-left: 14px" *ngIf="showBulkSelect">
                     <p-tableHeaderCheckbox></p-tableHeaderCheckbox>
                 </th>
-                <th [ngStyle]="_columnsMetadata.thumbnailUrl.style" *ngIf="_columnsMetadata.thumbnailUrl && !(_kmcPermissions.FEATURE_DISABLE_KMC_LIST_THUMBNAILS | kNgIfPermitted)">
+                <th [style]="_columnsMetadata.thumbnailUrl.style" *ngIf="_columnsMetadata.thumbnailUrl && !(_kmcPermissions.FEATURE_DISABLE_KMC_LIST_THUMBNAILS | kNgIfPermitted)">
                     {{'applications.content.table.thumbnail' | translate}}
                 </th>
-                <th [ngStyle]="_columnsMetadata.name.style" *ngIf="_columnsMetadata.name" [kpSortableColumn]="_columnsMetadata.name.sortable ? 'name' : null">
+                <th [style]="_columnsMetadata.name.style" *ngIf="_columnsMetadata.name" [kpSortableColumn]="_columnsMetadata.name.sortable ? 'name' : null">
                     {{'applications.content.table.name' | translate}}
                     <p-sortIcon [field]="'name'"  ></p-sortIcon>
                 </th>
-                <th [ngStyle]="_columnsMetadata.id.style" *ngIf="_columnsMetadata.id">{{'applications.content.table.id' |
+                <th [style]="_columnsMetadata.id.style" *ngIf="_columnsMetadata.id">{{'applications.content.table.id' |
                     translate}}
                 </th>
-                <th [ngStyle]="_columnsMetadata.mediaType.style" *ngIf="_columnsMetadata.mediaType" [kpSortableColumn]="_columnsMetadata.mediaType.sortable ? 'mediaType' : null">
+                <th [style]="_columnsMetadata.mediaType.style" *ngIf="_columnsMetadata.mediaType" [kpSortableColumn]="_columnsMetadata.mediaType.sortable ? 'mediaType' : null">
                     {{'applications.content.table.type' | translate}}
                     <p-sortIcon [field]="'mediaType'"></p-sortIcon>
                 </th>
-                <th [ngStyle]="_columnsMetadata.moderationCount.style" *ngIf="_columnsMetadata.moderationCount" [kpSortableColumn]="_columnsMetadata.moderationCount.sortable ? 'moderationCount' : null">
+                <th [style]="_columnsMetadata.moderationCount.style" *ngIf="_columnsMetadata.moderationCount" [kpSortableColumn]="_columnsMetadata.moderationCount.sortable ? 'moderationCount' : null">
                     {{'applications.content.table.flags' | translate}}
                     <p-sortIcon [field]="'moderationCount'"></p-sortIcon>
                 </th>
-                <th [ngStyle]="_columnsMetadata.createdAt.style" *ngIf="_columnsMetadata.createdAt" [kpSortableColumn]="_columnsMetadata.createdAt.sortable ? 'createdAt' : null">
+                <th [style]="_columnsMetadata.createdAt.style" *ngIf="_columnsMetadata.createdAt" [kpSortableColumn]="_columnsMetadata.createdAt.sortable ? 'createdAt' : null">
                     {{'applications.content.table.createdOn' | translate}}
                     <p-sortIcon [field]="'createdAt'"></p-sortIcon>
                 </th>
-                <th [ngStyle]="_columnsMetadata.moderationStatus.style" *ngIf="_columnsMetadata.moderationStatus">
+                <th [style]="_columnsMetadata.moderationStatus.style" *ngIf="_columnsMetadata.moderationStatus">
                     {{'applications.content.table.moderationStatus' | translate}}
                 </th>
-                <th [ngStyle]="_columnsMetadata.duration.style" *ngIf="_columnsMetadata.duration" [kpSortableColumn]="_columnsMetadata.duration.sortable ? 'duration' : null">
+                <th [style]="_columnsMetadata.duration.style" *ngIf="_columnsMetadata.duration" [kpSortableColumn]="_columnsMetadata.duration.sortable ? 'duration' : null">
                     {{'applications.content.table.duration' | translate}}
                     <p-sortIcon [field]="'duration'"></p-sortIcon>
                 </th>
-                <th [ngStyle]="_columnsMetadata.plays.style" *ngIf="_columnsMetadata.plays" [kpSortableColumn]="_columnsMetadata.plays.sortable ? 'plays' : null">
+                <th [style]="_columnsMetadata.plays.style" *ngIf="_columnsMetadata.plays" [kpSortableColumn]="_columnsMetadata.plays.sortable ? 'plays' : null">
                     {{'applications.content.table.plays' | translate}}
                     <p-sortIcon [field]="'plays'"></p-sortIcon>
                 </th>
-                <th [ngStyle]="_columnsMetadata.status.style" *ngIf="_columnsMetadata.status">
+                <th [style]="_columnsMetadata.status.style" *ngIf="_columnsMetadata.status">
                     {{'applications.content.table.status' | translate}}
                 </th>
                 <th *ngIf="rowActions?.length" style="width: 80px"></th>
-                <th [ngStyle]="_columnsMetadata.addToBucket.style" *ngIf="_columnsMetadata.addToBucket"></th>
+                <th [style]="_columnsMetadata.addToBucket.style" *ngIf="_columnsMetadata.addToBucket"></th>
             </tr>
         </ng-template>
 
@@ -65,7 +65,7 @@
                     <p-tableCheckbox [value]="entry"></p-tableCheckbox>
                 </td>
 
-                <td *ngIf="_columnsMetadata.thumbnailUrl && !(_kmcPermissions.FEATURE_DISABLE_KMC_LIST_THUMBNAILS | kNgIfPermitted)" [ngStyle]="_columnsMetadata.thumbnailUrl.style">
+                <td *ngIf="_columnsMetadata.thumbnailUrl && !(_kmcPermissions.FEATURE_DISABLE_KMC_LIST_THUMBNAILS | kNgIfPermitted)" [style]="_columnsMetadata.thumbnailUrl.style">
                     <div class="kThumbnailHolder"
                          [class.disable]="!_allowDrilldown('view', entry.mediaType,entry.status)"
                          (click)="_onActionSelected('view',entry)">
@@ -73,7 +73,7 @@
                     </div>
                 </td>
 
-                <td *ngIf="_columnsMetadata.name" [ngStyle]="_columnsMetadata.name.style">
+                <td *ngIf="_columnsMetadata.name" [style]="_columnsMetadata.name.style">
                     <span class="kTitle kTableColumn" [kTooltip]="entry.name"
                          [class.disable]="!_allowDrilldown('view', entry.mediaType,entry.status)"
                          (click)="_onActionSelected('view',entry)">
@@ -81,31 +81,31 @@
                     </span>
                 </td>
 
-                <td *ngIf="_columnsMetadata.id" [ngStyle]="_columnsMetadata.id.style">{{entry.id}}</td>
+                <td *ngIf="_columnsMetadata.id" [style]="_columnsMetadata.id.style">{{entry.id}}</td>
 
-                <td *ngIf="_columnsMetadata.mediaType" class="kMediaTypeIcon" [ngStyle]="_columnsMetadata.mediaType.style">
+                <td *ngIf="_columnsMetadata.mediaType" class="kMediaTypeIcon" [style]="_columnsMetadata.mediaType.style">
                     <div [kTooltip]="entry.mediaType | entryType: true"
                          [class]="entry.mediaType | entryType: false"></div>
                 </td>
 
-                <td *ngIf="_columnsMetadata.moderationCount" [ngStyle]="_columnsMetadata.moderationCount.style">
+                <td *ngIf="_columnsMetadata.moderationCount" [style]="_columnsMetadata.moderationCount.style">
                     {{entry.moderationCount}}
                 </td>
 
-                <td *ngIf="_columnsMetadata.createdAt" [ngStyle]="_columnsMetadata.createdAt.style">{{entry.createdAt | kDate}}
+                <td *ngIf="_columnsMetadata.createdAt" [style]="_columnsMetadata.createdAt.style">{{entry.createdAt | kDate}}
                 </td>
 
-                <td *ngIf="_columnsMetadata.moderationStatus" [ngStyle]="_columnsMetadata.moderationStatus.style">
+                <td *ngIf="_columnsMetadata.moderationStatus" [style]="_columnsMetadata.moderationStatus.style">
                     {{entry.moderationStatus | kModerationStatus}}
                 </td>
 
-                <td *ngIf="_columnsMetadata.duration" [ngStyle]="_columnsMetadata.duration.style">
+                <td *ngIf="_columnsMetadata.duration" [style]="_columnsMetadata.duration.style">
                     {{entry.duration | kTime | entryDuration:entry}}
                 </td>
 
-                <td *ngIf="_columnsMetadata.plays" [ngStyle]="_columnsMetadata.plays.style">{{entry.plays}}</td>
+                <td *ngIf="_columnsMetadata.plays" [style]="_columnsMetadata.plays.style">{{entry.plays}}</td>
 
-                <td *ngIf="_columnsMetadata.status" [ngStyle]="_columnsMetadata.status.style">{{entry | entryStatus}}</td>
+                <td *ngIf="_columnsMetadata.status" [style]="_columnsMetadata.status.style">{{entry | entryStatus}}</td>
 
                 <td *ngIf="rowActions?.length" style="overflow: visible; width: 80px">
                     <div class="kEntriesTableActions">
@@ -114,7 +114,7 @@
                     </div>
                 </td>
 
-                <td *ngIf="_columnsMetadata.addToBucket" [ngStyle]="_columnsMetadata.addToBucket.style">
+                <td *ngIf="_columnsMetadata.addToBucket" [style]="_columnsMetadata.addToBucket.style">
                     <div class="kEntriesTableActions">
                         <button type="button" pButton class="kButtonDefault kButtonAddToBucket" label="+"
                                 (click)="_onActionSelected('addToBucket', entry)"></button>


### PR DESCRIPTION
### PR information

**What is the current behavior?**
`[ngStyle]` is used to apply column style fails to work (styles are not applied)


**What is the new behavior?**
Replace `[ngStyle]` with `[style]` for entries table


**Does this PR introduce a breaking change?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/694)
<!-- Reviewable:end -->
