### PR TITLE
KMCNG-1968

### DIFF
--- a/src/shared/kmc-shared/kedit-hoster/kedit-hoster.component.ts
+++ b/src/shared/kmc-shared/kedit-hoster/kedit-hoster.component.ts
@@ -186,8 +186,21 @@ export class KeditHosterComponent implements OnInit, OnDestroy, OnChanges {
 
           if (clipAndTrimAvailable) {
               this._logger.debug('clip&trim views are available, add configuration for tabs: edit, quiz');
+              const clipAndTrimPermissions = [];
+              if (this._permissionService.hasPermission(KMCPermissions.CONTENT_INGEST_INTO_READY)) {
+                  clipAndTrimPermissions.push('trim');
+              }
+
+              if (this._permissionService.hasPermission(KMCPermissions.CONTENT_INGEST_CLIP_MEDIA)) {
+                  clipAndTrimPermissions.push('clip');
+              }
+
               Object.assign(tabs, {
-                  'edit': {name: 'edit', permissions: ['clip', 'trim'], userPermissions: ['clip', 'trim']}
+                  'edit': {
+                      name: 'edit',
+                      permissions: clipAndTrimPermissions,
+                      userPermissions: clipAndTrimPermissions
+                  }
               });
           }
 


### PR DESCRIPTION
### PR information

**What is the current behavior?**
When removing the clipping permissions from a partner, when opening KEA for clip and trip, you see "Save" disabled, and "Save a copy" enabled in the Save menu
https://kaltura.atlassian.net/browse/KMCNG-1968

**What is the new behavior?**
**Save a copy** button should not be shown 


**Does this PR introduce a breaking change?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/775)
<!-- Reviewable:end -->
