### PR TITLE
Fix resizable tables crash

### DIFF
--- a/src/applications/content-playlists-app/playlist/playlist-add-entry/playlist-add-entry.component.ts
+++ b/src/applications/content-playlists-app/playlist/playlist-add-entry/playlist-add-entry.component.ts
@@ -3,11 +3,16 @@ import { KalturaMediaEntry } from 'kaltura-ngx-client';
 import { AppLocalization } from '@kaltura-ng/mc-shared';
 import { KalturaEntryStatus } from 'kaltura-ngx-client';
 import { EntriesFilters } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
+import { ColumnsResizeManagerService, ResizableColumnsTableName } from 'app-shared/kmc-shared/columns-resize-manager';
 
 @Component({
   selector: 'kAddEntry',
   templateUrl: './playlist-add-entry.component.html',
-  styleUrls: ['./playlist-add-entry.component.scss']
+  styleUrls: ['./playlist-add-entry.component.scss'],
+    providers: [
+        ColumnsResizeManagerService,
+        { provide: ResizableColumnsTableName, useValue: 'manual-playlist-add-entries-table' }
+    ]
 })
 export class PlaylistAddEntryComponent {
   @Output() onClosePopupWidget = new EventEmitter<void>();

--- a/src/applications/content-playlists-app/playlist/playlist-content/rule-based/playlist-rule/playlist-rule.component.ts
+++ b/src/applications/content-playlists-app/playlist/playlist-content/rule-based/playlist-rule/playlist-rule.component.ts
@@ -14,6 +14,7 @@ import { KalturaEntryModerationStatus } from 'kaltura-ngx-client';
 import { KalturaEntryStatus } from 'kaltura-ngx-client';
 import { PlaylistRule } from './playlist-rule.interface';
 import { AreaBlockerMessage } from '@kaltura-ng/kaltura-ui';
+import { ColumnsResizeManagerService, ResizableColumnsTableName } from 'app-shared/kmc-shared/columns-resize-manager';
 
 @Component({
   selector: 'kPlaylistRule',
@@ -21,7 +22,9 @@ import { AreaBlockerMessage } from '@kaltura-ng/kaltura-ui';
   styleUrls: ['./playlist-rule.component.scss'],
   providers: [
     PlaylistRuleParserService,
-    { provide: EntriesStorePaginationCacheToken, useValue: 'entries-list' }
+    ColumnsResizeManagerService,
+    { provide: EntriesStorePaginationCacheToken, useValue: 'entries-list' },
+    { provide: ResizableColumnsTableName, useValue: 'rulebased-playlist-entries-table' }
   ]
 })
 export class PlaylistRuleComponent implements OnInit {

--- a/src/shared/content-shared/entries/link-entries-selector/linked-entries-add-entries/linked-entries-add-entries.component.ts
+++ b/src/shared/content-shared/entries/link-entries-selector/linked-entries-add-entries/linked-entries-add-entries.component.ts
@@ -5,6 +5,7 @@ import { AppLocalization } from '@kaltura-ng/mc-shared';
 import { EntriesStore, EntriesStorePaginationCacheToken } from 'app-shared/content-shared/entries/entries-store/entries-store.service';
 import { EntriesTableColumns } from 'app-shared/content-shared/entries/entries-table/entries-table.component';
 import { EntriesSelectorSelectionMode } from 'app-shared/content-shared/entries/entries-selector/entries-selector.component';
+import { ColumnsResizeManagerService, ResizableColumnsTableName } from 'app-shared/kmc-shared/columns-resize-manager';
 
 @Component({
   selector: 'k-linked-entries-add-entries-popup',
@@ -12,7 +13,9 @@ import { EntriesSelectorSelectionMode } from 'app-shared/content-shared/entries/
   styleUrls: ['./linked-entries-add-entries.component.scss'],
   providers: [
     EntriesStore,
-    { provide: EntriesStorePaginationCacheToken, useValue: 'linked-entries-selector' }
+    ColumnsResizeManagerService,
+    { provide: EntriesStorePaginationCacheToken, useValue: 'linked-entries-selector' },
+    { provide: ResizableColumnsTableName, useValue: 'linked-entries-add-entries-table' }
   ]
 })
 export class LinkedEntriesAddEntriesComponent implements OnInit {


### PR DESCRIPTION
### PR information

**What is the current behavior?**
The app crashes in
* rulebased playlist > add/edit rule popup
* manual playlist > add entries popup
* entry details > metadata > add linked entries


**What is the new behavior?**
Provide missing services to prevent crash


**Does this PR introduce a breaking change?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kmc-ng/777)
<!-- Reviewable:end -->
