### PR TITLE
fix(content/syndication): Handle Syndication feeds which use a playlist which is not loaded in the first 500 playlists

### DIFF
--- a/src/applications/content-syndication-app/feeds/feeds.service.ts
+++ b/src/applications/content-syndication-app/feeds/feeds.service.ts
@@ -4,7 +4,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs';
 import {ISubscription} from 'rxjs/Subscription';
 import 'rxjs/add/operator/map';
-import {KalturaFilterPager} from 'kaltura-ngx-client';
+import {KalturaFilterPager, PlaylistGetAction} from 'kaltura-ngx-client';
 import {KalturaClient, KalturaMultiRequest, KalturaMultiResponse, KalturaRequest} from 'kaltura-ngx-client';
 import {KalturaLogger} from '@kaltura-ng/kaltura-logger';
 import {
@@ -236,6 +236,11 @@ export class FeedsService extends FiltersStoreBase<FeedsFilters> implements OnDe
         return response.objects;
       });
 
+  }
+  public getPlaylist(id: string): Observable<KalturaPlaylist> {
+    return this._kalturaClient.request(
+      new PlaylistGetAction({id})
+    );
   }
 
   // bulk delete

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1031,6 +1031,7 @@
                     },
                     "errors": {
                         "loadFailed":  "An error occurred during Feed data loading.",
+                        "deletedPlaylist":  "The playlist used to create this feed could not be found (deleted?)\nMissing playlist ID: {{0}}\n\nPlease create a new feed.",
                         "enterName": "You must enter a Name to save the feed.",
                         "chooseDestination": "You must choose a destination to save the  feed.",
                         "fieldRequired": "This field is required."


### PR DESCRIPTION
### PR information

**What is the current behavior?**
* https://kaltura.atlassian.net/browse/SUP-17726
* Also handled trying to open a feed using a deleted playlist

**What is the new behavior?**
* feeds which use a playlist which is not loaded in the first 500 playlists are returned properly
* trying to open a feed using a deleted playlist results in the correct error message

**Does this PR introduce a breaking change?**
No