### PR TITLE
fix: Server poll invalid KS handling

### DIFF
--- a/src/shared/kmc-shared/server-polls/kmc-server-polls.service.ts
+++ b/src/shared/kmc-shared/server-polls/kmc-server-polls.service.ts
@@ -66,6 +66,10 @@ export class KmcServerPolls extends ServerPolls<KalturaRequestBase, KalturaAPIEx
       return this._kalturaClient.multiRequest(multiRequest.setNetworkTag('pr'))
           .pipe(
               map(responses => {
+                  if (responses.hasErrors()) {
+                      throw responses.getFirstError();
+                  }
+
                   return requestsMapping.reduce((aggregatedResponses, requestSize) => {
                       const response = responses.splice(0, requestSize);
                       const unwrappedResponse = response.length === 1 ? response[0] : response;

--- a/src/shared/kmc-shared/server-polls/kmc-server-polls.service.ts
+++ b/src/shared/kmc-shared/server-polls/kmc-server-polls.service.ts
@@ -25,6 +25,9 @@ export class KmcServerPolls extends ServerPolls<KalturaRequestBase, KalturaAPIEx
       _appEvents.event(UserLoginStatusEvent).subscribe(
           event => {
               this._isLogged = event.isLogged;
+              if (this._isLogged) {
+                  this._isKSValid = true;
+              }
           }
       );
   }


### PR DESCRIPTION
### PR information

**What is the current behavior?**
https://kaltura.atlassian.net/browse/KMCNG-2110

After the KS expires the app keeps sending requests to the server with invalid KS


**What is the new behavior?**
After the client receives INVALID_KS error code for the server polls requests iteration, it stops sending any polls requests as they all will faile with the same error.


**Does this PR introduce a breaking change?**