### PR TITLE
fixed 'Standalone Preview' link

### DIFF
--- a/src/applications/preview-and-embed/preview-embed.component.ts
+++ b/src/applications/preview-and-embed/preview-embed.component.ts
@@ -96,7 +96,7 @@ export class PreviewEmbedDetailsComponent implements OnInit, AfterViewInit, OnDe
       if (this._selectedPlayerVersion === 2) {
           this._generatedCode = this.generateCode(false);
           this._generatedPreviewCode = this.generateCode(true);
-          this.createPreviewLink(false);
+          this.createPreviewLink();
       } else {
           if (this._previewForm.controls['selectedEmbedType'].value === 'thumb'){
               // if coming from a V2 player with thumb embed, change the embed type to dynamic. This will trigger another change that will generate the correct embed code.
@@ -105,7 +105,7 @@ export class PreviewEmbedDetailsComponent implements OnInit, AfterViewInit, OnDe
           } else {
               this._generatedCode = this.generateV3code(false);
               this._generatedPreviewCode = this.generateV3code(true);
-              this.createPreviewLink(false);
+              this.createPreviewLink();
           }
       }
       this.showPreview();
@@ -355,18 +355,27 @@ export class PreviewEmbedDetailsComponent implements OnInit, AfterViewInit, OnDe
   }
 
   private flashVarsToUrl(flashVarsObject: any): string{
-      let params = '';
+      let
+          params = '',
+          index = 0;
       for( let i in flashVarsObject ){
         var curVal = typeof flashVarsObject[i] == 'object'? JSON.stringify( flashVarsObject[i] ): flashVarsObject[i];
-        params+= '&' + 'flashvars[' + encodeURIComponent( i ) + ']=' + encodeURIComponent(curVal);
+
+        if (index !== 0) {
+            params += '&';
+        }
+
+        params+= 'flashvars[' + encodeURIComponent( i ) + ']=' + encodeURIComponent(curVal);
+
+        index++;
       }
       return params;
   }
 
-  private createPreviewLink(isPreview: boolean):void{
+  private createPreviewLink():void{
       let url = '';
       try {
-        url = this.getProtocol(isPreview) + '://' + serverConfig.kalturaServer.uri + '/index.php/extwidget/preview';
+        url = this.getProtocol(true) + '://' + serverConfig.kalturaServer.uri + '/index.php/extwidget/preview';
         url += '/partner_id/' + this._appAuthentication.appUser.partnerId;
         url += '/uiconf_id/' + this._previewForm.controls['selectedPlayer'].value.uiConf.id;
         if (this.media instanceof KalturaMediaEntry) {
@@ -374,7 +383,7 @@ export class PreviewEmbedDetailsComponent implements OnInit, AfterViewInit, OnDe
         }
         url += '/embed/' + this._previewForm.controls['selectedEmbedType'].value;
         if (this._selectedPlayerVersion === 2 ) {
-            url += '?' + this.flashVarsToUrl(this.getEmbedFlashVars(isPreview));
+            url += '?' + this.flashVarsToUrl(this.getEmbedFlashVars(true));
         }
         this._previewLink = url;
       } catch (e){

--- a/src/configuration/server-config.ts
+++ b/src/configuration/server-config.ts
@@ -211,7 +211,7 @@ export const externalAppsConfigurationAdapter: ExternalAppsAdapter<ExternalAppli
                 !configuration.uri.match(/\s/g); // not contains white spaces
 
             if (result) {
-                configuration.uri = buildBaseUri(configuration.uri);
+                configuration.uri = configuration.uri.indexOf('http') === 0 ? configuration.uri : buildBaseUri(configuration.uri);
             }
         }
 

--- a/src/configuration/server-config.ts
+++ b/src/configuration/server-config.ts
@@ -211,7 +211,7 @@ export const externalAppsConfigurationAdapter: ExternalAppsAdapter<ExternalAppli
                 !configuration.uri.match(/\s/g); // not contains white spaces
 
             if (result) {
-                configuration.uri = configuration.uri.indexOf('http') === 0 ? configuration.uri : buildBaseUri(configuration.uri);
+                configuration.uri = buildBaseUri(configuration.uri);
             }
         }
 


### PR DESCRIPTION
### PR information

**What is the current behavior?**

The link 'Standalone Preview' located in 'Share & Embed' it's not correct.
To the method 'createPreviewLink' was always passing the param isPreview = false,
this method doesn't need to receive isPreview value, isPreview has to be always true

Small issue in the method 'flashVarsToUrl', the & was added also for the first param of the URL


**What is the new behavior?**
Fixed the method 'createPreviewLink' removing the input parameter 'isPreview' and setting to true where was used.
Fixed the method 'flashVarsToUrl' adding the & only for the params after the first

**Does this PR introduce a breaking change?**
NO