### PR TITLE
fixed 'liveAnalytics' method to support external resource

### DIFF
--- a/src/configuration/server-config.ts
+++ b/src/configuration/server-config.ts
@@ -211,7 +211,7 @@ export const externalAppsConfigurationAdapter: ExternalAppsAdapter<ExternalAppli
                 !configuration.uri.match(/\s/g); // not contains white spaces
 
             if (result) {
-                configuration.uri = buildBaseUri(configuration.uri);
+                configuration.uri = configuration.uri.indexOf('http') === 0 ? configuration.uri : buildBaseUri(configuration.uri);
             }
         }
 


### PR DESCRIPTION
### PR information

**What is the current behavior?**
Live analytics doesn't support an external resource


**What is the new behavior?**
Now support external resource, fixed the issue as it is for 'kmcAnalytics'


**Does this PR introduce a breaking change?**
NO