### PR TITLE
fix(content/entries): Load thumbnails for entries with access control profile requiring KS to show thumbnail

### DIFF
--- a/src/shared/content-shared/entries/entries-table/entries-table.component.html
+++ b/src/shared/content-shared/entries/entries-table/entries-table.component.html
@@ -129,7 +129,8 @@
                     <div class="kThumbnailHolder" #holder
                          [class.disable]="!_allowDrilldown('view', entry.mediaType,entry.status)"
                          (click)="_onActionSelected('view',entry)">
-                        <img *ngIf="entry.thumbnailUrl" [src]="entry.thumbnailUrl" onError="this.onerror=null;this.style.display='none'" (error)="holder.classList.add('error')">
+                        <img *ngIf="entry.thumbnailUrl" [src]="entry.thumbnailUrl" onError="this.onerror=null;this.style.display='none'" (error)="thumbks.src=entry.thumbnailUrl+'/ks/'+_ks">
+                        <img #thumbks onError="this.onerror=null;this.style.display='none'" (error)="holder.classList.add('error')">
                         <i class="kIconwarning"></i>
                         <i class="kIconyoutube kThumbnailTypeIcon" *ngIf="entry.externalSourceType === _youtubeExternalSourceType"></i>
                         <div class="kYoutubeIconFix" *ngIf="entry.externalSourceType === _youtubeExternalSourceType"></div>

--- a/src/shared/content-shared/entries/entries-table/entries-table.component.ts
+++ b/src/shared/content-shared/entries/entries-table/entries-table.component.ts
@@ -15,6 +15,7 @@ import { KalturaMediaEntry } from 'kaltura-ngx-client';
 import { globalConfig } from 'config/global';
 import { KMCPermissions } from 'app-shared/kmc-shared/kmc-permissions';
 import { ColumnsResizeManagerService } from 'app-shared/kmc-shared/columns-resize-manager';
+import { AppAuthentication } from "app-shared/kmc-shell";
 
 export interface EntriesTableColumns {
   [key: string]: {
@@ -85,15 +86,18 @@ export class EntriesTableComponent implements AfterViewInit, OnInit {
   private _deferredLoading = true;
   public _emptyMessage = '';
   public _defaultSortOrder = globalConfig.client.views.tables.defaultSortOrder;
+  public _ks = '';
 
   constructor(public _columnsResizeManager: ColumnsResizeManagerService,
               private _appLocalization: AppLocalization,
+              private _appAuthentication: AppAuthentication,
               private _cdRef: ChangeDetectorRef,
               private _el: ElementRef<HTMLElement>) {
   }
 
   ngOnInit() {
     this._emptyMessage = this._appLocalization.get('applications.content.table.noResults');
+    this._ks = this._appAuthentication.appUser.ks;
 
     Object.keys(this._columns).forEach(columnName => {
       this._columnsMetadata[columnName] = {


### PR DESCRIPTION
when failing to load entry thumbnail - try one more time with ks and if failing again - display no thumbnail icon

### PR information

**What is the current behavior?**



**What is the new behavior?**



**Does this PR introduce a breaking change?**