### PR TITLE
chore: update tiny link protocol according to app protocol

### DIFF
--- a/src/applications/preview-and-embed/preview-embed.component.ts
+++ b/src/applications/preview-and-embed/preview-embed.component.ts
@@ -401,7 +401,7 @@ export class PreviewEmbedDetailsComponent implements OnInit, AfterViewInit, OnDe
       // create short link
       this._previewEmbedService.generateShortLink(url).pipe(cancelOnDestroy(this)).subscribe(
           (res: KalturaShortLink) => {
-            this._shortLink = 'http://' + serverConfig.kalturaServer.uri + '/tiny/' + res.id;
+            this._shortLink = this.getProtocol(false) + '://' + serverConfig.kalturaServer.uri + '/tiny/' + res.id;
           },
           error => {
             console.log("could not generate short link for preview");


### PR DESCRIPTION
# PR information

**What is the current behavior?**

Original code generates preview URLs that begin with “http” regardless of whether the Kaltura server is secure or non-secure.
So that, users cannot see correct short link URLs when they employ secure servers.
Today, I propose this change in order to display the correct URLs.

**What is the new behavior?**

The new code appends "http" or "https" to the short link URLs depending on whether the Kaltura server users are accessing is secure or non-secure.

**Does this PR introduce a breaking change?**

No.
This is a minor change for the system.