### PR TITLE
style: Swapped padding-top to padding-bottom for IE

### DIFF
--- a/src/shared/content-shared/entries/entries-list/entries-list.component.scss
+++ b/src/shared/content-shared/entries/entries-list/entries-list.component.scss
@@ -61,8 +61,7 @@
 
     &.kAdditionalFilters {
       height: 150px;
-      padding-top: 28px;
-      align-items: start;
+      padding-bottom: 28px;
 
       .kFiltersWrapper {
         height: 88px;


### PR DESCRIPTION
### PR information
Eliminated 'align-items' which has no support on old browsers, and changed 'padding-top' to 'padding-bottom' for the same behavior.


**What is the current behavior?**
Layout breaks while using an old browser or specifically IE 11.
![ie11-layout](https://user-images.githubusercontent.com/6863655/72788898-f7b3ab80-3c32-11ea-90ac-d30451eabc2e.png)


**What is the new behavior?**
The layout should be the same on all browsers.


**Does this PR introduce a breaking change?**
No