### PR TITLE
feat(setting/access-control): Enhanced dropdown list to show more information on the selected items

### DIFF
--- a/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.html
+++ b/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.html
@@ -113,12 +113,21 @@
         <p-multiSelect class="kControl"
                        [options]="_countryCodes"
                        [showToggleAll]="false"
-                       [maxSelectedLabels]="0"
+                       [displaySelectedLabel]="false"
                        [resetFilterOnHide]="true"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findCountry' | translate"
-                       [selectedItemsLabel]="'applications.settings.accessControl.editForm.countriesSelected' | translate"
                        [formControl]="_allowedCountriesField"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate">
+          <ng-template let-selectedCountries pTemplate="selectedItems">
+            <span *ngFor="let selectedCountryCode of selectedCountries" class="kCountryList selected">
+              <i class="kFlag" [ngClass]="selectedCountryCode | kCountryFromCode:'icon'"></i>
+              {{selectedCountryCode | kCountryFromCode:'label'}}
+            </span>
+            <span *ngIf="selectedCountries && selectedCountries.length" class="selected-amount">
+              <span class="amount">{{selectedCountries.length}}</span>
+              <span>{{'applications.settings.accessControl.editForm.countriesSelected' | translate}}</span>
+            </span>
+          </ng-template>
           <ng-template let-country pTemplate="item">
             <span class="kCountryList">
                 <i class="kFlag" [ngClass]="country.value | kCountryFromCode:'icon'"></i>
@@ -136,17 +145,26 @@
         </span>
         <p-multiSelect class="kControl"
                        [options]="_countryCodes"
-                       [maxSelectedLabels]="0"
-                       [selectedItemsLabel]="'applications.settings.accessControl.editForm.countriesSelected' | translate"
+                       [displaySelectedLabel]="false"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findCountry' | translate"
                        [showToggleAll]="false"
                        [resetFilterOnHide]="true"
                        [formControl]="_restrictedCountriesField"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate">
+          <ng-template let-selectedCountries pTemplate="selectedItems">
+            <span *ngFor="let selectedCountryCode of selectedCountries" class="kCountryList selected">
+              <i class="kFlag" [ngClass]="selectedCountryCode | kCountryFromCode:'icon'"></i>
+              {{selectedCountryCode | kCountryFromCode:'label'}}
+            </span>
+            <span *ngIf="selectedCountries && selectedCountries.length" class="selected-amount">
+              <span class="amount">{{selectedCountries.length}}</span>
+              <span>{{'applications.settings.accessControl.editForm.countriesSelected' | translate}}</span>
+            </span>
+          </ng-template>
           <ng-template let-country pTemplate="item">
             <span class="kCountryList">
                 <i class="kFlag" [ngClass]="country.value | kCountryFromCode:'icon'"></i>
-              {{country.value | kCountryFromCode:'label'}}
+              {{country.label}}
               </span>
           </ng-template>
         </p-multiSelect>
@@ -235,13 +253,21 @@
                          [label]="'applications.settings.accessControl.editForm.selectedFlavorsOnly' | translate"></p-radioButton>
         </span>
         <p-multiSelect [options]="_store.flavors"
-                       [maxSelectedLabels]="0"
+                       [displaySelectedLabel]="false"
                        [formControl]="_allowedFlavorsField"
                        [resetFilterOnHide]="true"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findFlavor' | translate"
-                       [selectedItemsLabel]="'applications.settings.accessControl.editForm.flavorsSelected' | translate"
                        [showToggleAll]="false"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate">
+          <ng-template let-selectedFlavours pTemplate="selectedItems">
+            <span *ngFor="let selectedFlavourIndex of selectedFlavours" class="kFlavorList selected">
+              {{_store.getFlavorLabel(selectedFlavourIndex)}}
+            </span>
+            <span *ngIf="selectedFlavours && selectedFlavours.length" class="selected-amount">
+              <span class="amount">{{selectedFlavours.length}}</span>
+              <span>{{'applications.settings.accessControl.editForm.flavorsSelected' | translate}}</span>
+            </span>
+          </ng-template>
           <ng-template let-flavor pTemplate="item">
             <span class="kFlavorList">
               {{flavor.label}}
@@ -257,13 +283,21 @@
                          [label]="'applications.settings.accessControl.editForm.blockSelectedFlavors' | translate"></p-radioButton>
         </span>
         <p-multiSelect [options]="_store.flavors"
-                       [maxSelectedLabels]="0"
-                       [selectedItemsLabel]="'applications.settings.accessControl.editForm.flavorsSelected' | translate"
+                       [displaySelectedLabel]="false"
                        [showToggleAll]="false"
                        [resetFilterOnHide]="true"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findFlavor' | translate"
                        [formControl]="_restrictedFlavorsField"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate">
+          <ng-template let-selectedFlavours pTemplate="selectedItems">
+            <span *ngFor="let selectedFlavourIndex of selectedFlavours" class="kFlavorList selected">
+              {{_store.getFlavorLabel(selectedFlavourIndex)}}
+            </span>
+            <span *ngIf="selectedFlavours && selectedFlavours.length" class="selected-amount">
+              <span class="amount">{{selectedFlavours.length}}</span>
+              <span>{{'applications.settings.accessControl.editForm.flavorsSelected' | translate}}</span>
+            </span>
+          </ng-template>
           <ng-template let-flavor pTemplate="item">
             <span class="kFlavorList">
               {{flavor.label}}

--- a/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.html
+++ b/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.html
@@ -118,7 +118,7 @@
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findCountry' | translate"
                        [formControl]="_allowedCountriesField"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate"
-                       [class.item-selected]="_allowedCountriesField.value.length">
+                       [class.item-selected]="_allowedCountriesField && _allowedCountriesField.value && _allowedCountriesField.value.length">
           <ng-template let-selectedCountries pTemplate="selectedItems">
             <span *ngFor="let selectedCountryCode of selectedCountries" class="kCountryList selected">
               <i class="kFlag" [ngClass]="selectedCountryCode | kCountryFromCode:'icon'"></i>
@@ -152,7 +152,7 @@
                        [resetFilterOnHide]="true"
                        [formControl]="_restrictedCountriesField"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate"
-                       [class.item-selected]="_restrictedCountriesField.value.length">
+                       [class.item-selected]="_restrictedCountriesField && _restrictedCountriesField.value && _restrictedCountriesField.value.length">
           <ng-template let-selectedCountries pTemplate="selectedItems">
             <span *ngFor="let selectedCountryCode of selectedCountries" class="kCountryList selected">
               <i class="kFlag" [ngClass]="selectedCountryCode | kCountryFromCode:'icon'"></i>
@@ -261,7 +261,7 @@
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findFlavor' | translate"
                        [showToggleAll]="false"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate"
-                       [class.item-selected]="_allowedFlavorsField.value.length">
+                       [class.item-selected]="_allowedFlavorsField && _allowedFlavorsField.value && _allowedFlavorsField.value.length">
           <ng-template let-selectedFlavours pTemplate="selectedItems">
             <span *ngFor="let selectedFlavourIndex of selectedFlavours" class="kFlavorList selected">
               {{_store.getFlavorLabel(selectedFlavourIndex)}}
@@ -292,7 +292,7 @@
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findFlavor' | translate"
                        [formControl]="_restrictedFlavorsField"
                        [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate"
-                       [class.item-selected]="_restrictedFlavorsField.value.length">
+                       [class.item-selected]="_restrictedFlavorsField && _restrictedFlavorsField.value && _restrictedFlavorsField.value.length">
           <ng-template let-selectedFlavours pTemplate="selectedItems">
             <span *ngFor="let selectedFlavourIndex of selectedFlavours" class="kFlavorList selected">
               {{_store.getFlavorLabel(selectedFlavourIndex)}}

--- a/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.html
+++ b/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.html
@@ -117,7 +117,8 @@
                        [resetFilterOnHide]="true"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findCountry' | translate"
                        [formControl]="_allowedCountriesField"
-                       [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate">
+                       [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate"
+                       [class.item-selected]="_allowedCountriesField.value.length">
           <ng-template let-selectedCountries pTemplate="selectedItems">
             <span *ngFor="let selectedCountryCode of selectedCountries" class="kCountryList selected">
               <i class="kFlag" [ngClass]="selectedCountryCode | kCountryFromCode:'icon'"></i>
@@ -150,7 +151,8 @@
                        [showToggleAll]="false"
                        [resetFilterOnHide]="true"
                        [formControl]="_restrictedCountriesField"
-                       [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate">
+                       [defaultLabel]="'applications.settings.accessControl.editForm.selectCountry' | translate"
+                       [class.item-selected]="_restrictedCountriesField.value.length">
           <ng-template let-selectedCountries pTemplate="selectedItems">
             <span *ngFor="let selectedCountryCode of selectedCountries" class="kCountryList selected">
               <i class="kFlag" [ngClass]="selectedCountryCode | kCountryFromCode:'icon'"></i>
@@ -258,7 +260,8 @@
                        [resetFilterOnHide]="true"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findFlavor' | translate"
                        [showToggleAll]="false"
-                       [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate">
+                       [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate"
+                       [class.item-selected]="_allowedFlavorsField.value.length">
           <ng-template let-selectedFlavours pTemplate="selectedItems">
             <span *ngFor="let selectedFlavourIndex of selectedFlavours" class="kFlavorList selected">
               {{_store.getFlavorLabel(selectedFlavourIndex)}}
@@ -288,7 +291,8 @@
                        [resetFilterOnHide]="true"
                        [filterPlaceHolder]="'applications.settings.accessControl.editForm.findFlavor' | translate"
                        [formControl]="_restrictedFlavorsField"
-                       [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate">
+                       [defaultLabel]="'applications.settings.accessControl.editForm.selectFlavors' | translate"
+                       [class.item-selected]="_restrictedFlavorsField.value.length">
           <ng-template let-selectedFlavours pTemplate="selectedItems">
             <span *ngFor="let selectedFlavourIndex of selectedFlavours" class="kFlavorList selected">
               {{_store.getFlavorLabel(selectedFlavourIndex)}}

--- a/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.scss
+++ b/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.scss
@@ -135,7 +135,11 @@ $edit-profile-dropdown-max-width: 275px;
           &.selected {
             display: block;
             white-space: nowrap;
-            margin: 0.3em 0;
+            margin-bottom: 0.3em;
+
+            &:not(:first-child) {
+              margin-top: 0.3em;
+            }
           }
           &:not(.selected) {
           vertical-align: middle;
@@ -182,8 +186,13 @@ $edit-profile-dropdown-max-width: 275px;
     margin-left: 5px;
   }
 
+  p-multiSelect.item-selected .ui-multiselect .ui-multiselect-trigger {
+    display: none;
+  }
+
   .ui-multiselect-trigger {
     padding: .5em 1em;
+    height: 100%;
 
     .pi-caret-down {
       margin-left: -.25em;
@@ -242,6 +251,17 @@ $edit-profile-dropdown-max-width: 275px;
     }
   }
 
+  p-multiSelect {
+    &.item-selected {
+      .ui-multiselect .ui-multiselect-label-container {
+        padding-bottom: calc(1em + 16px);
+
+        .ui-multiselect-label {
+          box-shadow: 0 -3px 10px 3px transparentize(#000000, 0.7);
+        }
+      }
+    }
+
   .ui-multiselect {
       height: auto;
       width: calc(
@@ -256,19 +276,26 @@ $edit-profile-dropdown-max-width: 275px;
 
       .ui-multiselect-label-container {
         height: auto;
+        position: relative;
 
         .ui-multiselect-label {
           min-height: 34px;
+          max-height: 136px;
+          overflow: hidden;
+          overflow-y: scroll;
           height: auto;
           font-weight: normal;
-          padding: .5em;
+          padding: .5em .5em 0 .5em;
+          border-radius: 0;
 
           .selected-amount {
             border-bottom: 1px solid $kPrimary;
             font-size: 0.9em;
-            margin-top: 0.8em;
             display: inline-block;
             font-weight: 800;
+            position: absolute;
+            bottom: 0.5em; /* padding */
+            left: 0.5em; /* padding */
 
             .amount {
               margin-right: 0.2em;
@@ -277,6 +304,7 @@ $edit-profile-dropdown-max-width: 275px;
         }
       }
     }
+  }
 }
 
 :host .kEditAccessControlProfile .kContainer .kFormSection .kRow p-multiselect.kControl {

--- a/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.scss
+++ b/src/applications/settings-access-control-app/profiles/edit-profile/edit-profile.component.scss
@@ -2,6 +2,8 @@ $kmc-flags-path: '../../styles/flags/';
 @import "../../styles/flags/flags.scss";
 @import 'app-theme/_variables.scss';
 
+$edit-profile-dropdown-max-width: 275px;
+
 .kEditAccessControlProfile {
   .kHeader {
     height: 72px;
@@ -127,11 +129,19 @@ $kmc-flags-path: '../../styles/flags/';
           }
         }
         .kCountryList, .kFlavorList {
-          vertical-align: middle;
-          display: inline-block;
-          max-width: 275px;
+          max-width: $edit-profile-dropdown-max-width;
           overflow: hidden;
           text-overflow: ellipsis;
+          &.selected {
+            display: block;
+            white-space: nowrap;
+            margin: 0.3em 0;
+          }
+          &:not(.selected) {
+          vertical-align: middle;
+          display: inline-block;
+            white-space: normal;
+          }
 
           .kCountryListFlag {
             margin: 0 .125em 0 .5em;
@@ -170,11 +180,6 @@ $kmc-flags-path: '../../styles/flags/';
     font-weight: normal;
     font-size: 15px;
     margin-left: 5px;
-  }
-
-  .ui-multiselect-label {
-    font-weight: normal;
-    padding: .5em;
   }
 
   .ui-multiselect-trigger {
@@ -236,4 +241,44 @@ $kmc-flags-path: '../../styles/flags/';
       margin-right: 0;
     }
   }
+
+  .ui-multiselect {
+      height: auto;
+      width: calc(
+        #{$edit-profile-dropdown-max-width}
+        + 1em /*Padding*/
+        + 1.5em /*Dropdown Caret*/
+      );
+
+      .ui-multiselect-panel {
+        top: calc(100% + 1px) !important; // Overwrite inline style. (100% height of parent and 1px border)
+      }
+
+      .ui-multiselect-label-container {
+        height: auto;
+
+        .ui-multiselect-label {
+          min-height: 34px;
+          height: auto;
+          font-weight: normal;
+          padding: .5em;
+
+          .selected-amount {
+            border-bottom: 1px solid $kPrimary;
+            font-size: 0.9em;
+            margin-top: 0.8em;
+            display: inline-block;
+            font-weight: 800;
+
+            .amount {
+              margin-right: 0.2em;
+            }
+          }
+        }
+      }
+    }
+}
+
+:host .kEditAccessControlProfile .kContainer .kFormSection .kRow p-multiselect.kControl {
+  height: auto;
 }

--- a/src/applications/settings-access-control-app/profiles/profiles-store/profiles-store.service.ts
+++ b/src/applications/settings-access-control-app/profiles/profiles-store/profiles-store.service.ts
@@ -94,6 +94,16 @@ export class AccessControlProfilesStore extends FiltersStoreBase<AccessControlPr
     this._profiles.state.complete();
   }
 
+  public getFlavorLabel(flavorId: string): string {
+    const flavor = this.flavors.find(value => value.value === flavorId);
+
+    if (flavor) {
+      return flavor.label;
+    }
+
+    return '';
+  }
+
   private _prepare(): void {
     if (!this._isReady) {
       this._logger.info(`initiate service`);

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2720,8 +2720,8 @@
                     "selectCountry": "Land auswählen",
                     "findCountry": "Land suchen",
                     "findFlavor": "Variante suchen",
-                    "countriesSelected": " Länder ausgewählt",
-                    "flavorsSelected": " Varianten ausgewählt",
+                    "countriesSelected": "Länder ausgewählt",
+                    "flavorsSelected": "Varianten ausgewählt",
                     "invalidValue": "Ungültiger Wert",
                     "validationMessage": {
                         "invalidDomainName": "Ungültiger Domainname",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2720,8 +2720,8 @@
                     "selectCountry": "Land auswählen",
                     "findCountry": "Land suchen",
                     "findFlavor": "Variante suchen",
-                    "countriesSelected": "{0} Länder ausgewählt",
-                    "flavorsSelected": "{0} Varianten ausgewählt",
+                    "countriesSelected": " Länder ausgewählt",
+                    "flavorsSelected": " Varianten ausgewählt",
                     "invalidValue": "Ungültiger Wert",
                     "validationMessage": {
                         "invalidDomainName": "Ungültiger Domainname",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2837,8 +2837,8 @@
                     "selectCountry": "Select Country",
                     "findCountry": "Find Country",
                     "findFlavor": "Find Flavor",
-                    "countriesSelected": "{0} Countries Selected",
-                    "flavorsSelected": "{0} Flavors Selected",
+                    "countriesSelected": " Countries Selected",
+                    "flavorsSelected": " Flavors Selected",
                     "invalidValue": "Invalid Value",
                     "validationMessage": {
                         "invalidDomainName": "Invalid Domain Name",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2837,8 +2837,8 @@
                     "selectCountry": "Select Country",
                     "findCountry": "Find Country",
                     "findFlavor": "Find Flavor",
-                    "countriesSelected": " Countries Selected",
-                    "flavorsSelected": " Flavors Selected",
+                    "countriesSelected": "Countries Selected",
+                    "flavorsSelected": "Flavors Selected",
                     "invalidValue": "Invalid Value",
                     "validationMessage": {
                         "invalidDomainName": "Invalid Domain Name",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2720,8 +2720,8 @@
                     "selectCountry": "Seleccionar país",
                     "findCountry": "Buscar país",
                     "findFlavor": "Buscar sabor",
-                    "countriesSelected": "(0) países seleccionados",
-                    "flavorsSelected": "(0) sabores seleccionados",
+                    "countriesSelected": "países seleccionados",
+                    "flavorsSelected": "sabores seleccionados",
                     "invalidValue": "Valor inválido",
                     "validationMessage": {
                         "invalidDomainName": "Nombre de dominio inválido",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2720,8 +2720,8 @@
                     "selectCountry": "Sélectionner le pays",
                     "findCountry": "Trouver un pays",
                     "findFlavor": "Trouver un type",
-                    "countriesSelected": " Pays sélectionnés",
-                    "flavorsSelected": " Types sélectionnés",
+                    "countriesSelected": "Pays sélectionnés",
+                    "flavorsSelected": "Types sélectionnés",
                     "invalidValue": "Valeur non valide",
                     "validationMessage": {
                         "invalidDomainName": "Nom de domaine non valide",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2720,8 +2720,8 @@
                     "selectCountry": "Sélectionner le pays",
                     "findCountry": "Trouver un pays",
                     "findFlavor": "Trouver un type",
-                    "countriesSelected": "{0} Pays sélectionnés",
-                    "flavorsSelected": "{0} Types sélectionnés",
+                    "countriesSelected": " Pays sélectionnés",
+                    "flavorsSelected": " Types sélectionnés",
                     "invalidValue": "Valeur non valide",
                     "validationMessage": {
                         "invalidDomainName": "Nom de domaine non valide",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -2720,8 +2720,8 @@
                     "selectCountry": "国を選択",
                     "findCountry": "国を検索",
                     "findFlavor": "フレーバーを検索",
-                    "countriesSelected": "{0}件の国が選択されました",
-                    "flavorsSelected": "{0}件のフレーバーが選択されました",
+                    "countriesSelected": "件の国が選択されました",
+                    "flavorsSelected": "件のフレーバーが選択されました",
                     "invalidValue": "値が無効です",
                     "validationMessage": {
                         "invalidDomainName": "ドメイン名が無効です",


### PR DESCRIPTION
1. Updated captions and removed the number placeholder for `countriesSelected` and `flavoursSelected`.
2. Updated edit-profile.component.html:
   i. Adjusted p-multiSelect to eliminate use of label with placeholder.
   ii. Adjusted p-multiSelect to make use of selectedItems template. This consists of 'the selected list' and the amount selected.
3. Updated profiles-store.service.ts to retrieve the flavor label.
4. Updated styling to adjust the height automatically and position the elements accordingly.

### PR information

**What is the current behavior?**
When selecting an item from the dropdown, it is impossible to know which items you have selected unless you re-view the dropdown list as it displays only the amount selected.
Example: `2 Countries Selected` or `1 Flavour Selected`.


**What is the new behavior?**
Display the selected items (new), and as well as the number of selected items (as before).


**Does this PR introduce a breaking change?**
No.

### Testing

Tested on Chrome, Firefox, IE11, Edge, and Safari.
![chrome](https://user-images.githubusercontent.com/6863655/72816873-1e8cd480-3c69-11ea-8c15-342e675efe98.png)
![firefox](https://user-images.githubusercontent.com/6863655/72816876-1f256b00-3c69-11ea-8512-2faf93b09521.png)
![ie11](https://user-images.githubusercontent.com/6863655/72816877-1f256b00-3c69-11ea-8e24-573b04045bcb.png)
![edge](https://user-images.githubusercontent.com/6863655/72816878-1f256b00-3c69-11ea-88a5-ad5e7447cd94.png)
![safari](https://user-images.githubusercontent.com/6863655/72816879-1fbe0180-3c69-11ea-8ca7-a16d12dfe584.png)




