### PR TITLE
KMCNG-2366: Ignore empty secondaryRtspBroadcastingUrl

### DIFF
--- a/src/applications/content-entries-app/entry/entry-live/entry-live.component.html
+++ b/src/applications/content-entries-app/entry/entry-live/entry-live.component.html
@@ -46,8 +46,8 @@
           </div>
           <div class="kRow">
             <span class="kLabels">{{'applications.content.entryDetails.live.backup' | translate}}</span>
-            <span>{{_widgetService.data?.secondaryRtspBroadcastingUrl.replace('%i','1')}}</span>
-            <kCopyToClipboard class="kIcon" [text]="_widgetService.data?.secondaryRtspBroadcastingUrl.replace('%i','1')" [iconSwitchTimeout]="5000" [tooltips]="_copyToClipboardTooltips"></kCopyToClipboard>
+            <span>{{_widgetService.data?.secondaryRtspBroadcastingUrl?.replace('%i','1')}}</span>
+            <kCopyToClipboard class="kIcon" [text]="_widgetService.data?.secondaryRtspBroadcastingUrl?.replace('%i','1')" [iconSwitchTimeout]="5000" [tooltips]="_copyToClipboardTooltips"></kCopyToClipboard>
           </div>
         </div>
 


### PR DESCRIPTION
### PR information

**What is the current behavior?**
When there is no backup servers for live, errors are thrown and page doesn't render correctly.
URLs cannot be copied and used.


**What is the new behavior?**
Avoiding actions on the missing parameter from the API call. page renders as expected and empty fields are empty.


**Does this PR introduce a breaking change?**
No.