### PR TITLE
feat: add section for downloading child entries

### DIFF
--- a/src/applications/content-entries-app/content-entries-app.routes.ts
+++ b/src/applications/content-entries-app/content-entries-app.routes.ts
@@ -15,6 +15,7 @@ import {EntryThumbnails} from './entry/entry-thumbnails/entry-thumbnails.compone
 import {EntryCanDeactivate} from './entry/entry-can-deactivate.service';
 import {EntryDistributionComponent} from './entry/entry-distribution/entry-distribution.component';
 import {EntryAdvertisementsComponent} from './entry/entry-advertisements/entry-advertisements.component';
+import {EntryFlavoursChildren} from './entry/entry-flavours-children/entry-flavours-children.component';
 
 export const routing: Route[] = [
   {
@@ -34,6 +35,7 @@ export const routing: Route[] = [
           { path: 'accesscontrol', component: EntryAccessControl },
           { path: 'scheduling', component: EntryScheduling },
           { path: 'flavours', component: EntryFlavours },
+          { path: 'flavourschildren', component: EntryFlavoursChildren },
           { path: 'captions', component: EntryCaptions },
           { path: 'live', component: EntryLive },
           { path: 'related', component: EntryRelated },

--- a/src/applications/content-entries-app/entry/entry-components-list.ts
+++ b/src/applications/content-entries-app/entry/entry-components-list.ts
@@ -4,6 +4,7 @@ import {EntryThumbnailCapture} from './entry-thumbnails/entry-thumbnails-capture
 import {EntryAccessControl} from './entry-access-control/entry-access-control.component';
 import {EntryScheduling} from './entry-scheduling/entry-scheduling.component';
 import {EntryFlavours} from './entry-flavours/entry-flavours.component';
+import {EntryFlavoursChildren} from './entry-flavours-children/entry-flavours-children.component';
 import {DRMDetails} from './entry-flavours/drm-details/drm-details.component';
 import {FlavorPreview} from './entry-flavours/flavor-preview/flavor-preview.component';
 import {FlavorImport} from './entry-flavours/flavor-import/flavor-import.component';
@@ -55,6 +56,7 @@ export const EntryComponentsList = [
     EntryAdvertisementsComponent,
     EntryComponent,
     EntryFlavours,
+    EntryFlavoursChildren,
     EntryLive,
     EntryMetadata,
     EntryPreview,

--- a/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children-widget.service.ts
+++ b/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children-widget.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, OnDestroy } from '@angular/core';
+
+import { Observable } from 'rxjs';
+import { BrowserService } from 'app-shared/kmc-shell';
+import { KalturaMediaListResponse, KalturaMediaEntryFilter, KalturaFilterPager, MediaListAction, MediaGetAction, FlavorAssetGetDownloadUrlAction, KalturaClient } from 'kaltura-ngx-client';
+import { FlavorAssetGetFlavorAssetsWithParamsAction, KalturaMediaEntry, KalturaFlavorAssetWithParams } from 'kaltura-ngx-client';
+import { Flavor } from './flavor';
+import { EntryWidget } from '../entry-widget';
+import { ContentEntryViewSections } from 'app-shared/kmc-shared/kmc-views/details-views/content-entry-view.service';
+import { KalturaLogger } from '@kaltura-ng/kaltura-logger';
+import { AppLocalization } from '@kaltura-ng/mc-shared';
+import { cancelOnDestroy } from '@kaltura-ng/kaltura-common';
+
+@Injectable()
+export class EntryFlavoursChildrenWidget extends EntryWidget implements OnDestroy {
+    public showFlavorActions = true;
+
+    constructor(private _kalturaServerClient: KalturaClient,
+                private _appLocalization: AppLocalization,
+                private _browserService: BrowserService,
+                logger: KalturaLogger) {
+        super(ContentEntryViewSections.Flavours, logger);
+    }
+
+    /**
+     * Do some cleanups if needed once the section is removed
+     */
+    protected onReset() {
+        this.showFlavorActions = true;
+    }
+
+    protected onActivate(firstTimeActivating: boolean) {
+    }
+
+    public getEntry(entryid : string) : Observable<KalturaMediaEntry> {
+        const action = new MediaGetAction({
+            entryId: entryid
+        }) 
+        return this._kalturaServerClient.request(action)    }
+
+    public getFlavorAssetWithParams(entryid : string): Observable<KalturaFlavorAssetWithParams[]> {
+        const action = new FlavorAssetGetFlavorAssetsWithParamsAction({
+            entryId: entryid
+        }) 
+        return this._kalturaServerClient.request(action)
+    }
+    
+    public downloadFlavor(flavor: Flavor): void {
+        const id = flavor.flavorAsset.id;
+        this._kalturaServerClient.request(new FlavorAssetGetDownloadUrlAction({
+            id: id
+        }))
+            .pipe(cancelOnDestroy(this, this.widgetReset$))
+            .subscribe(
+                downloadUrl => {
+                    this._browserService.openLink(downloadUrl);
+                },
+                error => {
+                    this._browserService.showToastMessage({
+                        severity: 'error',
+                        detail: this._appLocalization.get('applications.content.entryDetails.flavours.downloadFailure')
+                    });
+                }
+            );
+    }
+    
+    public getChildEntries(entry : string) : Observable<KalturaMediaListResponse> {
+        const listMediaEntryAction = new MediaListAction({
+            filter: new KalturaMediaEntryFilter({
+                parentEntryIdEqual: entry
+            }),
+            pager: new KalturaFilterPager({ pageSize : 30})
+        });
+        return this._kalturaServerClient.request(listMediaEntryAction);
+    }
+
+    ngOnDestroy() {
+    }
+}

--- a/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children.component.html
+++ b/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children.component.html
@@ -1,0 +1,112 @@
+<k-area-blocker [showLoader]="_widgetService.showSectionLoader" [message]="_widgetService.sectionBlockerMessage"
+                [bodyScroll]="true">
+    <div class="kFlavours kOverrideFAIcons" #flavors>
+        <p class="kTitle">{{'applications.content.entryDetails.flavours.flavoursChildren' | translate}}</p>
+        <div *ngFor="let entry of childEntries">
+            <div class="kEntryId">
+                <p>Entryid: {{entry.id}}</p>
+                <p>Name: {{entry.name}}</p>
+            </div>
+            <div class="kTable">
+                <p-table
+                    scrollHeight="100%"
+                    [resizableColumns]="true"
+                    [value]="entry.flavors"
+                    [scrollable]="true"
+                    (onColResize)="_columnsResizeManager.onColumnResize($event)">
+                    <ng-template pTemplate="colgroup" let-columns>
+                        <colgroup>
+                            <col data-cid="name" [ngStyle]="{'width': '144px', 'padding-left': '24px'}">
+                            <col data-cid="assetId" [hidden]="_documentWidth < 1300" [ngStyle]="{'width': '100px'}">
+                            <col data-cid="format">
+                            <col data-cid="codec">
+                            <col data-cid="bitrate">
+                            <col data-cid="dimensions">
+                            <col data-cid="size">
+                            <col data-cid="stat">
+                            <col [ngStyle]="{'width':'80px'}">
+                        </colgroup>
+                    </ng-template>
+                    <ng-template pTemplate="header">
+                        <tr>
+                            <th data-cid="name" pResizableColumn
+                                [ngStyle]="{'width': '144px', 'padding-left': '24px'}">
+                                {{'applications.content.entryDetails.flavours.flavour' | translate}}
+                            </th>
+                            <th data-cid="assetId" pResizableColumn
+                                [ngStyle]="{'width': '100px'}"
+                                [hidden]="_documentWidth < 1300">
+                                {{'applications.content.entryDetails.flavours.assetId' | translate}}
+                            </th>
+                            <th data-cid="format" pResizableColumn>
+                                {{'applications.content.entryDetails.flavours.format' | translate}}
+                            </th>
+                            <th data-cid="codec" pResizableColumn>
+                                {{'applications.content.entryDetails.flavours.codec' | translate}}
+                            </th>
+                            <th data-cid="bitrate" pResizableColumn>
+                                {{'applications.content.entryDetails.flavours.bitrate' | translate}}
+                            </th>
+                            <th data-cid="dimensions" pResizableColumn>
+                                {{'applications.content.entryDetails.flavours.dimensions' | translate}}
+                            </th>
+                            <th data-cid="size" pResizableColumn>
+                                {{'applications.content.entryDetails.flavours.size' | translate}}
+                            </th>
+                            <th data-cid="stat" pResizableColumn>
+                                {{'applications.content.entryDetails.flavours.stat' | translate}}
+                            </th>
+                            <th [ngStyle]="{'width':'80px'}"></th>
+                        </tr>
+                    </ng-template>
+
+                    <ng-template pTemplate="body" let-flavor>
+                        <tr [pSelectableRow]="flavor">
+                            <td [ngStyle]="{'padding-left': '24px'}"class="ui-resizable-column">
+                                <span class="kFlavorName kTableColumn"
+                                    [class.kConvertedFlavor]="flavor.status === '2'">{{flavor.name}}</span>
+                            </td>
+                            <td class="ui-resizable-column" [hidden]="_documentWidth < 1300">
+                                <span class="kTableColumn" [kTooltip]="flavor.id" [showOnEllipsis]="true">{{flavor.id}}</span>
+                            </td>
+                            <td class="ui-resizable-column">
+                                <span class="kTableColumn" [kTooltip]="flavor.format" [showOnEllipsis]="true">{{flavor.format}}</span>
+                            </td>
+                            <td class="ui-resizable-column">
+                                <span class="kTableColumn" [kTooltip]="flavor.codec" [showOnEllipsis]="true">{{flavor.codec}}</span>
+                            </td>
+                            <td class="ui-resizable-column">
+                                <span class="kTableColumn" [kTooltip]="flavor.bitrate" [showOnEllipsis]="true">{{flavor.bitrate}}</span>
+                            </td>
+                            <td class="ui-resizable-column">
+                                <span class="kTableColumn" [kTooltip]="flavor.dimensions" [showOnEllipsis]="true">{{flavor.dimensions}}</span>
+                            </td>
+                            <td class="ui-resizable-column">
+                                <span class="kTableColumn" [kTooltip]="flavor.size" [showOnEllipsis]="true">{{flavor.size}}</span>
+                            </td>
+                            <td class="ui-resizable-column">
+                                <span class="kTableColumn" [kTooltip]="flavor.statusTooltip" [class.kFlavorStatusError]="flavor.status === '-1'">{{flavor.statusLabel}}</span>
+                            </td>
+                            <td>
+                                <div
+                                    *ngIf="_widgetService.showFlavorActions && flavor.status !== '1' && flavor.status !== '6' && flavor.status !== '7' && flavor.status !== '8' && flavor.status !== '0'"
+                                    class="kFlavorsTableActions">
+                                    <button type="button" class="kMoreActionsButton" pButton icon="kIconmore"
+                                            (click)="openActionsMenu($event, flavor)"></button>
+                                </div>
+                                <div
+                                    *ngIf="flavor.status === '1' || flavor.status === '6' || flavor.status === '7' || flavor.status === '8' || flavor.status === '0'"
+                                    style="position: relative">
+                                    <div class="k-spinner-background">
+                                        <div class="k-spinner-animation"></div>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    </ng-template>
+                </p-table>
+            </div>
+        </div>
+    </div>
+    <p-menu #actionsmenu [popup]="true" [model]="_actions" [appendTo]="'body'" kMenuCloseOnScroll></p-menu>
+</k-area-blocker>

--- a/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children.component.scss
+++ b/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children.component.scss
@@ -1,0 +1,54 @@
+@import 'app-theme/_variables.scss';
+
+
+.kFlavours{
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	button{
+		font-weight: 400;
+		height: 32px;
+	}
+	.kTitle{
+		padding-left: 24px;
+		color: $kGrayscale1;
+		font-size: 20px;
+		font-weight: 700;
+	}
+	.kEntryId{
+		padding-left: 24px;
+		margin-bottom: 24px;
+	}
+	.kTable{
+		.kFlavorName{
+			font-weight: bold;
+		}
+		.kConvertedFlavor{
+			color: $kGrayscale1;
+		}
+	}
+	.kTooltipHolder{
+		position: relative;
+	}
+	.kFlavorsTableActions {
+		width: 100%;
+		text-align: center;
+	}
+}
+:host ::ng-deep .p-button-icon-right.ui-c.pi-pi-fw.kIcondropdown_arrow_bottom{
+	font-size: 11px;
+	padding-right: 4px;
+}
+
+:host ::ng-deep p-table {
+    .p-datatable .p-datatable-thead > tr > th {
+        border-left: 1px solid $kGrayscale6;
+    }
+}
+
+@media screen and (max-width: 1310px) {
+    .kReplacementButtonsShown {
+        bottom: 22px !important;
+    }
+}

--- a/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children.component.ts
+++ b/src/applications/content-entries-app/entry/entry-flavours-children/entry-flavours-children.component.ts
@@ -1,0 +1,136 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AppLocalization } from '@kaltura-ng/mc-shared';
+import { KalturaFlavorAssetStatus, KalturaMediaEntry, KalturaFlavorAssetWithParams } from 'kaltura-ngx-client';
+import { Menu } from 'primeng/menu';
+import { EntryFlavoursChildrenWidget} from './entry-flavours-children-widget.service';
+import { Flavor } from './flavor';
+import { ColumnsResizeManagerService, ResizableColumnsTableName } from 'app-shared/kmc-shared/columns-resize-manager';
+import { MenuItem } from 'primeng/api';
+import { ActivatedRoute } from '@angular/router';
+
+export interface ChildEntry {
+    id: string,
+    name: string,
+    flavors: Flavor[]
+}
+
+@Component({
+    selector: 'kEntryFlavoursChildren',
+    templateUrl: './entry-flavours-children.component.html',
+    styleUrls: ['./entry-flavours-children.component.scss'],
+    providers: [
+        ColumnsResizeManagerService,
+        { provide: ResizableColumnsTableName, useValue: 'flavors-table' }
+    ]
+})
+export class EntryFlavoursChildren implements AfterViewInit, OnInit, OnDestroy {
+    @ViewChild('actionsmenu', { static: true }) 
+    private actionsMenu: Menu;
+    
+    public _actions: MenuItem[] = [];
+    public childEntries : ChildEntry[] = [];
+
+	public _selectedFlavor: Flavor;
+    public _loadingError = null;
+
+	public _documentWidth: number = 2000;
+	public _showActionsView = false;
+
+	constructor(public _columnsResizeManager: ColumnsResizeManagerService,
+                public _widgetService: EntryFlavoursChildrenWidget,
+                public route: ActivatedRoute,
+                private _appLocalization: AppLocalization) {
+
+        // Get childEntries and create Flavor objects.
+        const parentEntryId = this.route.parent.snapshot.url[1].path
+        this._widgetService.getChildEntries(parentEntryId).subscribe((mediaEntries) => {
+            if (mediaEntries.objects.length > 0) {
+                for (let mediaEntry of mediaEntries.objects) {
+                    this._widgetService.getFlavorAssetWithParams(mediaEntry.id).subscribe(
+                        (flavors) => {
+                            let tempFlavors: Flavor[] = [];
+                            for (let flavor of flavors) {
+                                if (flavor.flavorAsset && flavor.flavorAsset.size > 0) {
+                                tempFlavors.push(this._createFlavor(flavor));
+                                }
+                            }
+                            const childEntry = {
+                                name: mediaEntry.name,
+                                id: mediaEntry.id,
+                                flavors: Array.from(tempFlavors)
+                            }
+                            this.childEntries.push(childEntry)
+                        }
+                    )
+                }
+            }
+        })
+    }
+
+    private _createFlavor(flavor: KalturaFlavorAssetWithParams): Flavor {
+        let newFlavor : Flavor = <Flavor>flavor;
+        newFlavor.name = flavor.flavorParams ? flavor.flavorParams.name : '';
+        newFlavor.id = flavor.flavorAsset ? flavor.flavorAsset.id : '';
+        newFlavor.paramsId = flavor.flavorParams ? flavor.flavorParams.id : null;
+        newFlavor.isSource = flavor.flavorAsset ? flavor.flavorAsset.isOriginal : false;
+        newFlavor.isWeb = flavor.flavorAsset ? flavor.flavorAsset.isWeb : false;
+        newFlavor.format = flavor.flavorAsset ? flavor.flavorAsset.fileExt : '';
+        newFlavor.codec = flavor.flavorAsset ? flavor.flavorAsset.videoCodecId : '';
+        newFlavor.bitrate = (flavor.flavorAsset && flavor.flavorAsset.bitrate && flavor.flavorAsset.bitrate > 0) ? flavor.flavorAsset.bitrate.toString() : '';
+        newFlavor.size = flavor.flavorAsset ? (flavor.flavorAsset.status.toString() === KalturaFlavorAssetStatus.ready.toString() ? flavor.flavorAsset.size.toString() : '0') : '';
+        newFlavor.status = flavor.flavorAsset ? flavor.flavorAsset.status.toString() : '';
+        newFlavor.statusLabel = "";
+        newFlavor.statusTooltip = "";
+        newFlavor.tags = flavor.flavorAsset ? flavor.flavorAsset.tags : '-';
+
+        // set dimensions
+        const width: number = flavor.flavorAsset ? flavor.flavorAsset.width : flavor.flavorParams.width;
+        const height: number = flavor.flavorAsset ? flavor.flavorAsset.height : flavor.flavorParams.height;
+        const w: string = width === 0 ? "[auto]" : width.toString();
+        const h: string = height === 0 ? "[auto]" : height.toString();
+        newFlavor.dimensions = w + " x " + h;
+        
+        // set status
+        if (flavor.flavorAsset) {
+            newFlavor.statusLabel = this._appLocalization.get('applications.content.entryDetails.flavours.status.' + KalturaFlavorAssetStatus[flavor.flavorAsset.status]);
+            if (flavor.flavorAsset.status.toString() === KalturaFlavorAssetStatus.notApplicable.toString()) {
+                newFlavor.statusTooltip = this._appLocalization.get('applications.content.entryDetails.flavours.status.naTooltip');
+            }
+        }
+        return newFlavor;
+    }
+
+    ngOnInit() {
+	    this._documentWidth = document.body.clientWidth;
+    }
+
+	openActionsMenu(event: any, flavor: Flavor): void{
+		if (this.actionsMenu){
+			this._actions = [];
+			if (flavor.status === KalturaFlavorAssetStatus.exporting.toString() || flavor.status === KalturaFlavorAssetStatus.ready.toString() ) {
+				this._actions.push({id: 'download', label: this._appLocalization.get('applications.content.entryDetails.flavours.actions.download'), command: (event) => {this.actionSelected("download");}});
+			}
+			if (this._actions.length) {
+				this._selectedFlavor = flavor;
+				this.actionsMenu.toggle(event);
+			}
+		}
+	}
+
+	private actionSelected(action: string): void{
+		switch (action){
+			case "download":
+				this._widgetService.downloadFlavor(this._selectedFlavor);
+				break;
+            default:
+                break;
+		}
+	}
+
+    ngAfterViewInit(): void {
+    }
+
+    ngOnDestroy() {
+	    this.actionsMenu.hide();
+	}
+}

--- a/src/applications/content-entries-app/entry/entry-flavours-children/flavor.ts
+++ b/src/applications/content-entries-app/entry/entry-flavours-children/flavor.ts
@@ -1,0 +1,19 @@
+import { KalturaFlavorAssetWithParams } from 'kaltura-ngx-client';
+
+export interface Flavor extends KalturaFlavorAssetWithParams{
+    name: string,
+    id: string,
+    paramsId: number,
+    isSource: boolean,
+    isWeb: boolean,
+    format: string,
+    codec: string,
+    bitrate: string,
+    size: string,
+    dimensions: string,
+    status: string,
+    statusLabel: string,
+    statusTooltip: string,
+    tags: string,
+    uploadFileId: string
+}

--- a/src/applications/content-entries-app/entry/entry-sections-list/entry-sections-list-widget.service.ts
+++ b/src/applications/content-entries-app/entry/entry-sections-list/entry-sections-list-widget.service.ts
@@ -1,16 +1,18 @@
 import {Injectable, OnDestroy} from '@angular/core';
+import { KalturaClient, KalturaMediaEntry } from 'kaltura-ngx-client';
+import { KalturaMediaEntryFilter, MediaListAction, KalturaFilterPager} from 'kaltura-ngx-client'
 import { Observable } from 'rxjs';
 import {BehaviorSubject} from 'rxjs';
 import {AppLocalization} from '@kaltura-ng/mc-shared';
 import {SectionsList} from './sections-list';
 import { cancelOnDestroy, tag } from '@kaltura-ng/kaltura-common';
-import {KalturaMediaEntry} from 'kaltura-ngx-client';
 import {EntryWidget} from '../entry-widget';
 import {
     ContentEntryViewSections,
     ContentEntryViewService
 } from 'app-shared/kmc-shared/kmc-views/details-views/content-entry-view.service';
 import {KalturaLogger} from '@kaltura-ng/kaltura-logger';
+import { ActivatedRoute } from '@angular/router';
 
 export interface SectionWidgetItem {
     label: string;
@@ -23,13 +25,18 @@ export interface SectionWidgetItem {
 export class EntrySectionsListWidget extends EntryWidget implements OnDestroy
 {
     private _sections = new BehaviorSubject<SectionWidgetItem[]>([]);
+    private _stripFlavoursChildrenSection: boolean = false;
     public sections$ : Observable<SectionWidgetItem[]> = this._sections.asObservable();
 
     constructor(private _appLocalization: AppLocalization,
                 private _contentEntryViewService: ContentEntryViewService,
+                public route: ActivatedRoute,
+                private _kalturaServerClient: KalturaClient,
                 logger: KalturaLogger)
     {
         super('sectionsList', logger);
+        const entryId = this.route.snapshot.url[1].path
+        this._hasChildren(entryId)
     }
 
     protected onDataLoading(dataId : any) : void {
@@ -46,6 +53,26 @@ export class EntrySectionsListWidget extends EntryWidget implements OnDestroy
 
     protected onDataLoaded(data : KalturaMediaEntry) : void {
         this._reloadSections(data);
+    }
+
+    /**
+     * Evaluates if loaded entry has any children.
+     * If not, we're hiding the FlavoursChildren section.
+     *
+     * @param {string} id entryId
+     */
+    private _hasChildren(id : string) : void {
+        const listMediaEntryAction = new MediaListAction({
+            filter: new KalturaMediaEntryFilter({
+                parentEntryIdEqual: id
+            }),
+            pager: new KalturaFilterPager({ pageSize : 1})
+        });
+        this._kalturaServerClient.request(listMediaEntryAction).subscribe((response) => {
+            if (response.objects.length < 1) {
+                this._stripFlavoursChildrenSection = true;
+            }
+        })
     }
 
     private _initialize() : void {
@@ -88,7 +115,7 @@ export class EntrySectionsListWidget extends EntryWidget implements OnDestroy
 
         if (entry) {
             SectionsList.forEach((section) => {
-
+                if (section.key === ContentEntryViewSections.FlavoursChildren && this._stripFlavoursChildrenSection) { return }
                 const sectionFormWidgetState =  formWidgetsState ? formWidgetsState[section.key] : null;
                 const isSectionActive = sectionFormWidgetState && sectionFormWidgetState.isActive;
 

--- a/src/applications/content-entries-app/entry/entry-sections-list/sections-list.ts
+++ b/src/applications/content-entries-app/entry/entry-sections-list/sections-list.ts
@@ -22,6 +22,10 @@ export const SectionsList = [
         key : ContentEntryViewSections.Flavours
     },
     {
+        label : 'applications.content.entryDetails.sections.flavoursChildren',
+        key : ContentEntryViewSections.FlavoursChildren
+    },
+    {
         label : 'applications.content.entryDetails.sections.distribution',
         key : ContentEntryViewSections.Distribution
     },

--- a/src/applications/content-entries-app/entry/entry.component.ts
+++ b/src/applications/content-entries-app/entry/entry.component.ts
@@ -33,6 +33,7 @@ import { ContentEntriesAppService } from '../content-entries-app.service';
 import { BrowserService } from 'app-shared/kmc-shell/providers';
 import { KalturaLogger } from '@kaltura-ng/kaltura-logger';
 import { AnalyticsNewMainViewService } from 'app-shared/kmc-shared/kmc-views';
+import { EntryFlavoursChildrenWidget } from './entry-flavours-children/entry-flavours-children-widget.service';
 
 @Component({
 	selector: 'kEntry',
@@ -47,6 +48,7 @@ import { AnalyticsNewMainViewService } from 'app-shared/kmc-shared/kmc-views';
 		EntrySchedulingWidget,
 		EntryRelatedWidget,
 		EntryFlavoursWidget,
+		EntryFlavoursChildrenWidget,
 		EntryLiveWidget,
 		EntryClipsWidget,
 		EntryCaptionsWidget,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1521,6 +1521,7 @@
                     "accesscontrol": "Access Control",
                     "scheduling": "Scheduling",
                     "flavours": "Flavors",
+                    "flavoursChildren": "Flavors children",
                     "captions": "Captions",
                     "live": "Live Stream",
                     "related": "Related Files",
@@ -1643,6 +1644,7 @@
                 },
                 "flavours": {
                     "flavours": "Flavors",
+                    "flavoursChildren": "Flavors children",
                     "replace": "Replace Video",
                     "flavour": "Flavor",
                     "assetId": "Asset ID",

--- a/src/shared/kmc-shared/kmc-views/details-views/content-entry-view.service.ts
+++ b/src/shared/kmc-shared/kmc-views/details-views/content-entry-view.service.ts
@@ -25,6 +25,7 @@ export enum ContentEntryViewSections {
     AccessControl = 'AccessControl',
     Scheduling = 'Scheduling',
     Flavours = 'Flavours',
+    FlavoursChildren = 'FlavoursChildren',
     Captions = 'Captions',
     Live = 'Live',
     Related = 'Related',
@@ -104,6 +105,9 @@ export class ContentEntryViewService extends KmcDetailsViewBaseService<ContentEn
                     case 'flavours':
                         result = ContentEntryViewSections.Flavours;
                         break;
+                    case 'flavourschildren':
+                        result = ContentEntryViewSections.FlavoursChildren;
+                        break;
                     case 'captions':
                         result = ContentEntryViewSections.Captions;
                         break;
@@ -152,6 +156,9 @@ export class ContentEntryViewService extends KmcDetailsViewBaseService<ContentEn
             case ContentEntryViewSections.Flavours:
                 result = 'flavours';
                 break;
+            case ContentEntryViewSections.FlavoursChildren:
+                result = 'flavourschildren';
+                break;
             case ContentEntryViewSections.Captions:
                 result = 'captions';
                 break;
@@ -198,6 +205,7 @@ export class ContentEntryViewService extends KmcDetailsViewBaseService<ContentEn
         const externalMedia = entry instanceof KalturaExternalMediaEntry;
         let result = false;
         switch (section) {
+            case ContentEntryViewSections.FlavoursChildren:
             case ContentEntryViewSections.Flavours:
                 result = mediaType !== KalturaMediaType.image && !this._isLiveMediaEntry(entry.mediaType) && !externalMedia;
                 break;
@@ -255,6 +263,7 @@ export class ContentEntryViewService extends KmcDetailsViewBaseService<ContentEn
                 break;
             case ContentEntryViewSections.Thumbnails:
             case ContentEntryViewSections.Flavours:
+            case ContentEntryViewSections.FlavoursChildren:
             case ContentEntryViewSections.Clips:
             case ContentEntryViewSections.AccessControl:
             case ContentEntryViewSections.Scheduling:


### PR DESCRIPTION
### PR information

**What is the current behavior?**

It's difficult for users to download multivideo recordings
You have to use the API or at least browser developer tools

**What is the new behavior?**

This commit adds a "FlavoursChildren" section
It does not have all the features that the Flavour section has
It's only for downloading

![twoChildren](https://user-images.githubusercontent.com/66301426/157752969-6b1af074-8321-4170-ba78-c365449b2759.png)

**Does this PR introduce a breaking change?**
No