### PR TITLE
SUP-35187 Increase reach dictionary max chars to 8000

### DIFF
--- a/src/applications/settings-reach-app/reach-profile/reach-profile-dictionary/reach-profile-dictionary-widget.service.ts
+++ b/src/applications/settings-reach-app/reach-profile/reach-profile-dictionary/reach-profile-dictionary-widget.service.ts
@@ -17,7 +17,7 @@ export class ReachProfileDictionaryWidget extends ReachProfileWidget {
 
     public _languages: { label: string, value: string }[] = [];
     public _dictionaries: Dictionary[] = [];
-    public _maxCharacters = 4000;
+    public _maxCharacters = 8000;
 
     constructor(logger: KalturaLogger) {
         super(SettingsReachProfileViewSections.Dictionary, logger);


### PR DESCRIPTION
### PR information

**What is the current behavior?**
Reach dictionary max chars is 4000.


**What is the new behavior?**
Reach dictionary max chars is 8000.


**Does this PR introduce a breaking change?**