### PR TITLE
SUP-48811:  Groups not populating in Change owner Bulk Update in KMC

### DIFF
--- a/src/applications/content-entries-app/entries/bulk-actions/components/bulk-change-owner/bulk-change-owner.component.ts
+++ b/src/applications/content-entries-app/entries/bulk-actions/components/bulk-change-owner/bulk-change-owner.component.ts
@@ -116,7 +116,17 @@ export class BulkChangeOwner implements OnInit, OnDestroy, AfterViewInit {
                                 itemType: KalturaESearchItemType.startsWith,
                                 fieldName: KalturaESearchUserFieldName.userId,
                                 searchTerm: event.query
-                            })
+                            }),
+							new KalturaESearchUserItem({
+								itemType: KalturaESearchItemType.partial,
+								fieldName: KalturaESearchUserFieldName.screenName,
+								searchTerm: event.query
+							}),
+							new KalturaESearchUserItem({
+								itemType: KalturaESearchItemType.partial,
+								fieldName: KalturaESearchUserFieldName.userId,
+								searchTerm: event.query
+							})
                         ]
                     })
                 }),


### PR DESCRIPTION
**Issue:**
The search was missing two fields in the user search query:
screenName (partial match)
userId (partial match)
This caused incomplete results when users searched by partial user ID or screen name.

**Fix:**
Added the following missing search fields to the user search query:
- KalturaESearchUserFieldName.screenName with itemType: partial
- KalturaESearchUserFieldName.userId with itemType: partial