### PR TITLE
fix(SUP-49493): KMC - Error when deleting more than 25 entries 

### DIFF
--- a/src/applications/content-entries-app/entries/bulk-actions/bulk-actions.component.ts
+++ b/src/applications/content-entries-app/entries/bulk-actions/bulk-actions.component.ts
@@ -305,9 +305,10 @@ export class BulkActionsComponent implements OnInit, OnDestroy {
     this._analytics.trackClickEvent('Bulk_delete');
     const entriesToDelete = this.selectedEntries.map((entry, index) => `${index + 1}: ${entry.name}` ),
       entries: string = this.selectedEntries.length <= 10 ? entriesToDelete.join(',').replace(/,/gi, '\n') : '',
-      message: string = this.selectedEntries.length > 1 ?
-        this._appLocalization.get('applications.content.entries.confirmDeleteMultiple', { 0: entries }) :
-        this._appLocalization.get('applications.content.entries.confirmDeleteSingle', { 0: entries });
+      message: string = this.selectedEntries.length == 1 ?
+      this._appLocalization.get('applications.content.entries.confirmDeleteSingle', { 0: entries }) : this.selectedEntries.length >= 25 ?
+        this._appLocalization.get('applications.content.entries.confirmDeleteMultipleOver25', { 0: entries }) :
+        this._appLocalization.get('applications.content.entries.confirmDeleteMultiple', { 0: entries });
     this._browserService.confirm(
       {
         header: this._appLocalization.get('applications.content.bulkActions.deleteEntries'),

--- a/src/applications/content-entries-app/entries/bulk-actions/bulk-actions.component.ts
+++ b/src/applications/content-entries-app/entries/bulk-actions/bulk-actions.component.ts
@@ -303,13 +303,14 @@ export class BulkActionsComponent implements OnInit, OnDestroy {
   // bulk delete
   public deleteEntries(): void {
     this._analytics.trackClickEvent('Bulk_delete');
-    const entriesToDelete = this.selectedEntries.map((entry, index) => `${index + 1}: ${entry.name}` ),
+    
+    if(this.selectedEntries.length < 25) {
+      const entriesToDelete = this.selectedEntries.map((entry, index) => `${index + 1}: ${entry.name}` ),
       entries: string = this.selectedEntries.length <= 10 ? entriesToDelete.join(',').replace(/,/gi, '\n') : '',
-      message: string = this.selectedEntries.length == 1 ?
-      this._appLocalization.get('applications.content.entries.confirmDeleteSingle', { 0: entries }) : this.selectedEntries.length >= 25 ?
-        this._appLocalization.get('applications.content.entries.confirmDeleteMultipleOver25', { 0: entries }) :
-        this._appLocalization.get('applications.content.entries.confirmDeleteMultiple', { 0: entries });
-    this._browserService.confirm(
+      message: string = this.selectedEntries.length > 1 ?
+        this._appLocalization.get('applications.content.entries.confirmDeleteMultiple', { 0: entries }) :
+        this._appLocalization.get('applications.content.entries.confirmDeleteSingle', { 0: entries });
+        this._browserService.confirm(
       {
         header: this._appLocalization.get('applications.content.bulkActions.deleteEntries'),
         message: message,
@@ -320,6 +321,15 @@ export class BulkActionsComponent implements OnInit, OnDestroy {
         }
       }
     );
+    } else {
+      this._browserService.alert({
+        header: this._appLocalization.get('applications.content.bulkActions.deleteEntries'),
+        message: this._appLocalization.get('applications.content.entries.deleteMultipleOver25Limit', { 0 : this.selectedEntries.length }),
+        accept: () => {
+          return;
+        }
+      })
+    }
   }
 
   // bulk download initial check

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -790,7 +790,7 @@
                 "confirmDelete": "Are you sure you want to delete the selected entry?",
                 "confirmDeleteSingle": "Are you sure you want to delete the selected entry? \n {{0}} \n Please note: the entry will be permanently deleted from your account.",
                 "confirmDeleteMultiple": "Are you sure you want to delete the selected entries? \n {{0}} \n Please note: these entries will be permanently deleted from your account.",
-                "confirmDeleteMultipleOver25": "Are you sure you want to delete the selected entries? \n {{0}} \n Please note: these entries will be permanently deleted from your account. \n Note: You can delete up to 25 entries at a time.",
+                "deleteMultipleOver25Limit": "You selected {{0}} entries, but only 25 can be deleted at once. Please reduce your selection and try again.",
                 "entryId": "Entry ID: {{0}}",
                 "deleteNote": "Please note: the entry will be permanently deleted from your account.",
                 "ruleName": "Rule Name",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -790,6 +790,7 @@
                 "confirmDelete": "Are you sure you want to delete the selected entry?",
                 "confirmDeleteSingle": "Are you sure you want to delete the selected entry? \n {{0}} \n Please note: the entry will be permanently deleted from your account.",
                 "confirmDeleteMultiple": "Are you sure you want to delete the selected entries? \n {{0}} \n Please note: these entries will be permanently deleted from your account.",
+                "confirmDeleteMultipleOver25": "Are you sure you want to delete the selected entries? \n {{0}} \n Please note: these entries will be permanently deleted from your account. \n Note: You can delete up to 25 entries at a time.",
                 "entryId": "Entry ID: {{0}}",
                 "deleteNote": "Please note: the entry will be permanently deleted from your account.",
                 "ruleName": "Rule Name",


### PR DESCRIPTION
**Issue:**
Delete more than 25 entries in once is not allowed and the customer doesn't have an input for that.

**Fix:**
Add a warning message.