### PR TITLE
fix: direction-aware scheduling criteria filter mapping SUP-53253

### DIFF
--- a/src/applications/settings-mr-app/rule/criteria/renderers/scheduling.component.ts
+++ b/src/applications/settings-mr-app/rule/criteria/renderers/scheduling.component.ts
@@ -48,16 +48,16 @@ export class CriteriaSchedulingComponent implements OnInit{
     public isValid = true;
 
     public _startDateOptions: { value: string, label: string }[] = [
-        {value: 'startDateGreaterThanOrEqual', label: this._appLocalization.get('applications.settings.mr.criteria.less')},
-        {value: 'startDateLessThanOrEqual', label: this._appLocalization.get('applications.settings.mr.criteria.more')}
+        {value: 'less', label: this._appLocalization.get('applications.settings.mr.criteria.less')},
+        {value: 'more', label: this._appLocalization.get('applications.settings.mr.criteria.more')}
     ];
-    public _startDateOptionSelected = 'startDateLessThanOrEqual';
+    public _startDateOptionSelected = 'less';
 
     public _endDateOptions: { value: string, label: string }[] = [
-        {value: 'endDateGreaterThanOrEqual', label: this._appLocalization.get('applications.settings.mr.criteria.less')},
-        {value: 'endDateLessThanOrEqual', label: this._appLocalization.get('applications.settings.mr.criteria.more')}
+        {value: 'less', label: this._appLocalization.get('applications.settings.mr.criteria.less')},
+        {value: 'more', label: this._appLocalization.get('applications.settings.mr.criteria.more')}
     ];
-    public _endDateOptionSelected = 'endDateLessThanOrEqual';
+    public _endDateOptionSelected = 'less';
 
     public schedulingStartTime = 0;
     public schedulingStartTimeUnit = 'day';
@@ -90,7 +90,7 @@ export class CriteriaSchedulingComponent implements OnInit{
                 if (typeof val === "string") {
                     this.isValid = false;
                 } else {
-                    this._startDateOptionSelected = key;
+                    this._startDateOptionSelected = this._getComparison(key, val.numberOfUnits);
                     this.schedulingStartTime = Math.abs(value[key].numberOfUnits) || 0;
                     this.periodStartTimeUnit = value[key].numberOfUnits < 0 ? -1 : 1;
                     this.schedulingStartTimeUnit = val.dateUnit  || 'day';
@@ -104,7 +104,7 @@ export class CriteriaSchedulingComponent implements OnInit{
                 if (typeof val === "string") {
                     this.isValid = false;
                 } else {
-                    this._endDateOptionSelected = key;
+                    this._endDateOptionSelected = this._getComparison(key, val.numberOfUnits);
                     this.schedulingEndTime = Math.abs(value[key].numberOfUnits) || 0;
                     this.periodEndTimeUnit = value[key].numberOfUnits < 0 ? -1 : 1;
                     this.schedulingEndTimeUnit = val.dateUnit  || 'day';
@@ -125,6 +125,23 @@ export class CriteriaSchedulingComponent implements OnInit{
     ngOnInit(): void {
     }
 
+    /**
+     * The comparison the user picks ('less'/'more') maps to a different filter field depending on the
+     * selected direction: 'less than N days ago' is a lower bound (now - N), while 'less than N days
+     * ahead' is an upper bound (now + N).
+     */
+    private _getFilterField(prefix: 'startDate' | 'endDate', comparison: string, direction: number): string {
+        const ago = direction < 0;
+        const isUpperBound = ago ? comparison === 'more' : comparison === 'less';
+        return `${prefix}${isUpperBound ? 'LessThanOrEqual' : 'GreaterThanOrEqual'}`;
+    }
+
+    private _getComparison(field: string, numberOfUnits: number): string {
+        const ago = numberOfUnits < 0;
+        const isUpperBound = field.endsWith('LessThanOrEqual');
+        return ago === isUpperBound ? 'more' : 'less';
+    }
+
     public onCriteriaChange(): void {
         delete this._filter['startDateGreaterThanOrEqual'];
         delete this._filter['startDateLessThanOrEqual'];
@@ -132,22 +149,22 @@ export class CriteriaSchedulingComponent implements OnInit{
         delete this._filter['endDateLessThanOrEqual'];
         let analyticsLabel = "";
         if (this._enableStartTime) {
-            this._filter[this._startDateOptionSelected] = {
+            this._filter[this._getFilterField('startDate', this._startDateOptionSelected, this.periodStartTimeUnit)] = {
                 numberOfUnits: this.schedulingStartTime * this.periodStartTimeUnit,
                 dateUnit: this.schedulingStartTimeUnit
             };
-            analyticsLabel += this._startDateOptionSelected === 'startDateLessThanOrEqual' ? 'start_date_less_' : 'start_date_more_';
+            analyticsLabel += this._startDateOptionSelected === 'less' ? 'start_date_less_' : 'start_date_more_';
             analyticsLabel += `${this.schedulingStartTime}-${this.schedulingStartTimeUnit}`;
         }
         if (this._enableEndTime) {
-            this._filter[this._endDateOptionSelected] = {
+            this._filter[this._getFilterField('endDate', this._endDateOptionSelected, this.periodEndTimeUnit)] = {
                 numberOfUnits: this.schedulingEndTime * this.periodEndTimeUnit,
                 dateUnit: this.schedulingEndTimeUnit
             };
             if (this._enableStartTime) {
                 analyticsLabel += ';';
             }
-            analyticsLabel += this._startDateOptionSelected === '_endDateOptionSelected' ? 'end_date_less_' : 'end_date_more_';
+            analyticsLabel += this._endDateOptionSelected === 'less' ? 'end_date_less_' : 'end_date_more_';
             analyticsLabel += `${this.schedulingEndTime}-${this.schedulingEndTimeUnit}`;
         }
         if (analyticsLabel !== "") {


### PR DESCRIPTION
## SUP-53253 — Automation Manager Test Run returns incorrect entries for expiration criteria

Regression from `1c78f42d` (PLAT-25941).

### Root cause

The Automation Manager scheduling criteria reads as `[Less than | More than] [N] [days…] [ago | ahead]`, but the dropdown's option `value` **was** the Kaltura filter field name — so the label→field mapping could not depend on the ago/ahead selection at all.

PLAT-25941 swapped that mapping unconditionally. The swap is correct for **ago**, but for **ahead** it inverts the comparison: "End Date less than 15 days ahead" was saved to the rule as `endDateGreaterThanOrEqual: now+15d`, which is why the customer's Test Run returned entries expiring in 2027–2029.

### Fix

`src/applications/settings-mr-app/rule/criteria/renderers/scheduling.component.ts`:

- Dropdown values are now semantic (`'less'` / `'more'`) rather than filter field names, for both start and end date.
- Two helpers translate between UI state and filter, taking direction into account:
  - `_getFilterField(prefix, comparison, direction)` — building the filter in `onCriteriaChange()`
  - `_getComparison(field, numberOfUnits)` — reading a saved rule back in the `filter` setter

Resulting mapping:

| Direction | Less than | More than |
|---|---|---|
| ago | `…GreaterThanOrEqual` | `…LessThanOrEqual` |
| ahead | `…LessThanOrEqual` | `…GreaterThanOrEqual` |

Two side effects of the old coupling are also resolved: the default dropdown selection displayed "More than" after the PLAT commit (now "Less than" again), and the end-date analytics label compared against the literal string `'_endDateOptionSelected'`, so it always reported `end_date_more_`.

### Verification

- `tsc --noEmit` on the changed file is clean (only the repo's pre-existing `@types/core-js` conflicts, unchanged).
- No spec files exist for these renderers; the mapping was hand-traced across all four direction/comparison combinations, including the save → reopen round trip through `_getComparison`.
- **Remaining manual check:** build a rule with "End Date less than 15 days ahead", save, reopen to confirm the dropdowns read back correctly, then run a Test Run.

### Out of scope

With the correct mapping, "End Date less than 15 days ahead" means `endDate <= now+15d`, which literally still includes **already-expired** entries — also flagged in the ticket. Excluding them requires a lower bound (`endDateGreaterThanOrEqual: now`), which is a semantics change rather than a bug fix, and belongs either to the user's rule configuration or to `ovp-media-repurposing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
